### PR TITLE
feat: 공통 응답 포맷 통일 및 GlobalExceptionHandler 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/CustomException.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/CustomException.java
@@ -1,0 +1,26 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import lombok.Getter;
+
+/**
+ * ErrorCode를 기반으로 한 공통 사용자 정의 예외 클래스입니다.
+ * <p>
+ * 모든 비즈니스 예외는 본 예외를 상속하거나 사용하여 발생시키며,
+ * 전역 예외 처리기에서 ErrorCode를 기준으로 공통 실패 응답으로 변환됩니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorcode) {
+		super(errorcode.getMessage());
+		this.errorCode = errorcode;
+	}
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 실패 응답에 사용되는 공통 에러 코드 규약 인터페이스입니다.
+ *
+ * <p>
+ * 모든 도메인별 에러 코드(enum)는 본 인터페이스를 구현하며,
+ * 전역 예외 처리기(GlobalExceptionHandler)는 ErrorCode 타입을 기준으로
+ * HTTP 상태 코드와 응답 메시지를 결정합니다.
+ * </p>
+ *
+ * <p>
+ * 이를 통해 도메인별 에러 코드가 추가되더라도 예외 처리 로직을 수정하지 않고 확장할 수 있습니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+public interface ErrorCode {
+
+	String getCode();
+
+	String getMessage();
+
+	HttpStatus getHttpStatus();
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorResponse.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorResponse.java
@@ -1,0 +1,67 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+/**
+ * API 실패 응답에 사용되는 공통 에러 응답 DTO입니다.
+ *
+ * <p>
+ * 모든 실패 응답은 본 객체로 감싸서 반환되며, ErrorCode를 기반으로 응답 코드 및 메시지를 구성합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class ErrorResponse {
+
+	private final boolean success = false;
+	private final String code;
+	private final String message;
+	private final List<FieldError> errors;
+	private final LocalDateTime timestamp;
+
+	private ErrorResponse(String code, String message, List<FieldError> errors) {
+		this.code = code;
+		this.message = message;
+
+		if (errors == null) {
+			this.errors = Collections.emptyList();
+		} else {
+			this.errors = errors;
+		}
+
+		this.timestamp = LocalDateTime.now();
+	}
+
+	/**
+	 * ErrorCode 기반 기본 실패 응답
+	 */
+	public static ErrorResponse from(ErrorCode errorCode) {
+		return new ErrorResponse(
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			Collections.emptyList()
+		);
+	}
+
+	/**
+	 * Validation 오류를 포함한 실패 응답
+	 */
+	public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+
+		return new ErrorResponse(
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			errors
+		);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorResponse.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ErrorResponse.java
@@ -26,10 +26,10 @@ public final class ErrorResponse {
 	private final boolean success = false;
 	private final String code;
 	private final String message;
-	private final List<FieldError> errors;
+	private final List<ValidationFieldError> errors;
 	private final LocalDateTime timestamp;
 
-	private ErrorResponse(String code, String message, List<FieldError> errors) {
+	private ErrorResponse(String code, String message, List<ValidationFieldError> errors) {
 		this.code = code;
 		this.message = message;
 
@@ -56,7 +56,7 @@ public final class ErrorResponse {
 	/**
 	 * Validation 오류를 포함한 실패 응답
 	 */
-	public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+	public static ErrorResponse of(ErrorCode errorCode, List<ValidationFieldError> errors) {
 
 		return new ErrorResponse(
 			errorCode.getCode(),

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/FieldError.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/FieldError.java
@@ -1,0 +1,24 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Validation 실패 시 필드 단위 오류 정보를 표현하는 DTO입니다.
+ *
+ * <p>
+ * 입력 값 검증 과정에서 발생한 오류를 필드별로 전달하기 위해 사용되며,
+ * {@link ErrorResponse}의 errors 필드에 포함됩니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+@RequiredArgsConstructor
+public final class FieldError {
+
+	private final String field;
+	private final String reason;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
@@ -1,0 +1,33 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 애플리케이션 전역에서 공통으로 사용되는 에러 코드를 정의한 enum입니다.
+ *
+ * <p>
+ * 특정 도메인(auth, user, admin 등)에 종속되지 않는 요청 오류 및 시스템 오류를 표현합니다.
+ * </p>
+ *
+ * <p>
+ * 도메인 특화 에러는 각 도메인별 ErrorCode(enum)로 분리하여 관리합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+	INVALID_REQUEST("G400", "INVALID_REQUEST", HttpStatus.BAD_REQUEST),
+	INTERNAL_SERVER_ERROR("G500", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.github.sleeplessspecialist.peaktime.global.common.error;
+
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 애플리케이션 전역에서 발생하는 예외를 공통 실패 응답({@link ErrorResponse})으로 변환하는 핸들러입니다.
+ * <p>
+ * - 비즈니스 예외: {@link CustomException}
+ * - 입력 값 검증 예외: {@link MethodArgumentNotValidException}
+ * - 그 외 예외: {@link Exception}
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		log.warn("비즈니스 예외 발생: code={}, message={}",
+			errorCode.getCode(), errorCode.getMessage());
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.from(errorCode));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e) {
+
+		log.warn("요청 값 검증 실패: {}건의 오류 발생",
+			e.getBindingResult().getErrorCount());
+
+        List<ValidationFieldError> errors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+				.map(ValidationFieldError::from)
+                .toList();
+
+		return ResponseEntity
+			.status(GlobalErrorCode.INVALID_REQUEST.getHttpStatus())
+			.body(ErrorResponse.of(GlobalErrorCode.INVALID_REQUEST, errors));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("처리되지 않은 예외 발생", e);
+		return ResponseEntity
+			.status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+			.body(ErrorResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ValidationFieldError.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ValidationFieldError.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Getter
 @RequiredArgsConstructor
-public final class FieldError {
+public final class ValidationFieldError {
 
 	private final String field;
 	private final String reason;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ValidationFieldError.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/ValidationFieldError.java
@@ -21,4 +21,16 @@ public final class ValidationFieldError {
 
 	private final String field;
 	private final String reason;
+
+	/**
+	 * Spring Validation FieldError를 API 응답용 ValidationFieldError로 변환합니다.
+	 */
+	public static ValidationFieldError from(
+		org.springframework.validation.FieldError fieldError) {
+
+		return new ValidationFieldError(
+			fieldError.getField(),
+			fieldError.getDefaultMessage()
+		);
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
@@ -1,0 +1,85 @@
+package com.github.sleeplessspecialist.peaktime.global.common.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 공통 성공 응답을 위한 표준 API 응답 래퍼 클래스입니다.
+ *
+ * <p>
+ * 모든 컨트롤러의 성공 응답은 ApiResponse로 감싸서 반환하며,
+ * 실패 응답은 GlobalExceptionHandler에서 ErrorResponse로 처리합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class ApiResponse<T> {
+
+	private final boolean success;
+	private final String code;
+	private final String message;
+	private final T data;
+	private final LocalDateTime timestamp;
+
+	/**
+	 * 데이터가 없는 기본 성공 응답
+	 */
+	public static <T> ApiResponse<T> ok() {
+		return new ApiResponse<>(
+			true,
+			SuccessCode.OK.getCode(),
+			SuccessCode.OK.getMessage(),
+			null,
+			LocalDateTime.now()
+		);
+	}
+
+	/**
+	 * 데이터를 포함한 기본 성공 응답
+	 */
+	public static <T> ApiResponse<T> ok(T data) {
+		return new ApiResponse<>(
+			true,
+			SuccessCode.OK.getCode(),
+			SuccessCode.OK.getMessage(),
+			data,
+			LocalDateTime.now()
+		);
+	}
+
+	/**
+	 * 커스텀 성공 코드 (데이터 없음)
+	 */
+	public static <T> ApiResponse<T> of(SuccessCode successCode) {
+		return new ApiResponse<>(
+			true,
+			successCode.getCode(),
+			successCode.getMessage(),
+			null,
+			LocalDateTime.now()
+		);
+	}
+
+	/**
+	 * 커스텀 성공 코드 + 데이터
+	 */
+	public static <T> ApiResponse<T> of(SuccessCode successCode, T data) {
+		return new ApiResponse<>(
+			true,
+			successCode.getCode(),
+			successCode.getMessage(),
+			data,
+			LocalDateTime.now()
+		);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * API 성공 응답에 사용되는 비즈니스 성공 코드입니다.
+ *
+ * <p>
+ * HTTP Status와 별도로, 요청이 비즈니스적으로 정상 처리되었음을 표현합니다.
+ * 기본 성공 코드는 {@code S000}이며 HTTP 200 OK에 대응합니다.
+ * </p>
+ *
+ * <p>
+ * v1에서는 공통 성공 코드(OK)만 사용하며,
+ * 도메인별 성공 코드가 필요해질 경우 분리할 수 있습니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+
+	OK("S000", "OK");
+
+	private final String code;
+	private final String message;
+
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
Closes #13 
Closes #15 
Closes #17 



---

## ✨ 작업 내용
공통 응답 포맷(성공/실패)을 통일하고, 전역 예외 처리를 통해 모든 실패 케이스를 ErrorResponse로 변환하도록 구성했습니다.


✅ 공통 성공 응답
- ApiResponse<T> 공통 성공 응답 래퍼 도입
- SuccessCode 기반으로 성공 코드/메시지 표준화

✅ 공통 실패 응답 + 예외 체계
- ErrorCode 인터페이스로 에러 코드 규약 정의
- GlobalErrorCode(전역 공통 에러) 정의
- CustomException 도입: 도메인별 ErrorCode를 담아 일관된 방식으로 예외 발생
- ErrorResponse(공통 실패 응답) + ValidationFieldError(검증 오류 DTO) 정의
- ValidationFieldError.from(...) 정적 팩토리로 Spring Validation 오류를 응답 DTO로 변환

✅ GlobalExceptionHandler
- @RestControllerAdvice 기반 전역 예외 처리기 구현
  - CustomException → ErrorResponse.from(errorCode)
  - MethodArgumentNotValidException(Validation) → ErrorResponse.of(INVALID_REQUEST, errors)
  - Exception → INTERNAL_SERVER_ERROR로 통일
- 로깅 추가(@Slf4j)
  - Validation/비즈니스 예외: WARN
  - 예상치 못한 예외: ERROR + stacktrace

### 성공 응답 예시
```json
{
  "success": true,
  "code": "S000",
  "message": "OK",
  "data": {},
  "timestamp": "2026-01-21T12:00:00"
}
```

### 실패 응답 예시 - Validation 오류 (잘못된 요청)
- Validation 오류는 보안 및 내부 규칙 노출을 최소화하기 위해 필드명 + 요약 사유(reason) 형태로 제공합니다.
```json
{
  "success": false,
  "code": "G400",
  "message": "INVALID_REQUEST",
  "errors": [
    {
      "field": "email",
      "reason": "형식이 올바르지 않습니다"
    },
    {
      "field": "password",
      "reason": "유효하지 않습니다"
    }
  ],
  "timestamp": "2026-01-21T12:00:00"
}
```
### 비즈니스 예외 (CustomException)
- 비즈니스 예외는 CustomException(ErrorCode) 기반으로 처리되며, code / message는 해당 도메인 ErrorCode를 따릅니다.
```json
{
  "success": false,
  "code": "A404001",
  "message": "USER_NOT_FOUND",
  "timestamp": "2026-01-21T12:00:00"
}
```
> ※ 위 code 값(A404001)은 예시이며, 실제 값은 각 도메인 ErrorCode 정의를 따릅니다.

### 예상치 못한 예외 (서버 내부 오류)
- 처리되지 않은 예외는 전역 에러 코드로 통일하며, 상세 원인은 응답에 포함하지 않고 로그로만 기록합니다.
```json
{
  "success": false,
  "code": "G500",
  "message": "INTERNAL_SERVER_ERROR",
  "timestamp": "2026-01-21T12:00:00"
}
```
---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.

---

## 💬 리뷰어에게
- 공통 응답 포맷을 먼저 고정하기 위해 성공/실패 응답과 전역 예외 처리까지 포함했습니다.
- Validation 오류(ValidationFieldError)는 Spring 타입을 직접 노출하지 않도록 변환했습니다.
- Security(401/403) 예외를 공통 포맷으로 통일하는 처리는 보안 단계에서 별도 PR로 진행할 예정입니다.
- 응답 포맷(success / code / message / data / timestamp) 및 SuccessCode 확장 방향에 대한 의견이 있으면 자유롭게 남겨주세요.