### PR TITLE
[feat] 공통 보안 설정 기본 골격 구성

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
@@ -25,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 public enum GlobalErrorCode implements ErrorCode {
 
 	INVALID_REQUEST("G400", "INVALID_REQUEST", HttpStatus.BAD_REQUEST),
+	UNAUTHORIZED("G401", "UNAUTHORIZED", HttpStatus.UNAUTHORIZED),
+	ACCESS_DENIED("G403", "ACCESS_DENIED", HttpStatus.FORBIDDEN),
 	INTERNAL_SERVER_ERROR("G500", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final String code;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.github.sleeplessspecialist.peaktime.global.common.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.github.sleeplessspecialist.peaktime.global.common.security.handler.RestAccessDeniedHandler;
+import com.github.sleeplessspecialist.peaktime.global.common.security.handler.RestAuthenticationEntryPoint;
+import com.github.sleeplessspecialist.peaktime.global.common.security.policy.SecurityPathPolicy;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Spring Security의 기본 필터 체인을 구성하는 설정 클래스입니다.
+ *
+ * <p>
+ * 초기 개발 단계에서는 모든 요청을 허용하며,
+ * 인증/인가 실패에 대한 공통 처리(401/403 JSON 응답)만 연결합니다.
+ * </p>
+ *
+ * <p>
+ * 이후 인증/인가 정책이 확정되면,
+ * {@link SecurityPathPolicy}의 경로를 기준으로 점진적으로 보호 정책을 강화합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final RestAuthenticationEntryPoint authenticationEntryPoint;
+	private final RestAccessDeniedHandler accessDeniedHandler;
+
+	/**
+	 * Spring Security 필터 체인을 정의합니다.
+	 *
+	 * <p>
+	 * 초기 개발 단계에서는 기능 개발을 막지 않기 위해 모든 요청을 허용합니다.
+	 * 다만, 인증 인가 정책이 적용되는 시점에 대비하여 401,403 공통 처리 핸들러는 미리 연결합니다.
+	 * </p>
+	 *
+	 * @param http HttpSecurity 설정 객체
+	 * @return 구성된 {@link SecurityFilterChain}
+	 * @throws Exception 보안 설정 과정에서 발생할 수 있는 예외
+	 */
+	@Bean
+	public SecurityFilterChain springSecurityFilterChain(HttpSecurity http) throws Exception {
+
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(session
+				-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable())
+
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(authenticationEntryPoint)
+				.accessDeniedHandler(accessDeniedHandler)
+			)
+
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll()
+			);
+		return http.build();
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
 	 * @throws Exception 보안 설정 과정에서 발생할 수 있는 예외
 	 */
 	@Bean
-	public SecurityFilterChain springSecurityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
 		http
 			.csrf(csrf -> csrf.disable())

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/handler/RestAccessDeniedHandler.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/handler/RestAccessDeniedHandler.java
@@ -1,0 +1,76 @@
+package com.github.sleeplessspecialist.peaktime.global.common.security.handler;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorResponse;
+import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
+
+import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 인가 실패(403) 처리 Handler 입니다.
+ * <p>
+ * 인증은 되었으나 해당 리소스에 접근할 권한이 없는 경우 호출되며,
+ * 서비스의 공통 실패 응답 포맷(ErrorResponse)으로 JSON 에러를 반환합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 인가(Authorization)에 실패했을 때 호출되는 메서드입니다.
+	 *
+	 * <p>
+	 * 인증은 완료되었으나 사용자가 요청한 리소스에 접근할 권한이 없는 경우,
+	 * Spring Security 필터 체인 단계에서 실행되며
+	 * 컨트롤러에 진입하기 전에 HTTP 403(Forbidden) 상태 코드와 함께
+	 * 공통 실패 응답 포맷({@link ErrorResponse})을 JSON 형태로 반환합니다.
+	 * </p>
+	 *
+	 * @param request 인가 실패가 발생한 HTTP 요청 객체
+	 * @param response 인가 실패 응답을 작성할 HTTP 응답 객체
+	 * @param accessDeniedException 인가 실패 원인에 대한 예외 정보
+	 * @throws IOException 응답 본문(JSON) 작성 중 발생할 수 있는 예외
+	 * @throws ServletException 서블릿 처리 과정에서 발생할 수 있는 예외
+	 */
+	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException
+	) throws IOException, ServletException {
+
+		log.warn("인가 실패. requestURI={}, method={}, exception={}",
+			request.getRequestURI(),
+			request.getMethod(),
+			accessDeniedException.getClass().getSimpleName()
+		);
+
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		GlobalErrorCode errorCode = GlobalErrorCode.ACCESS_DENIED;
+		ErrorResponse body = ErrorResponse.from(errorCode);
+
+		objectMapper.writeValue(response.getWriter(), body);
+	}
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/handler/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/handler/RestAuthenticationEntryPoint.java
@@ -1,0 +1,74 @@
+package com.github.sleeplessspecialist.peaktime.global.common.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorResponse;
+import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 인증 실패(401) 처리 EntryPoint 입니다.
+ * <p>
+ * 보호된 리소스에 대해 인증 정보가 없거나 유효하지 않을 때 호출되며,
+ * 서비스의 공통 실패 응답 포맷(ErrorResponse)으로 JSON 에러를 반환합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 인증되지 않은 사용자가 보호된 리소스에 접근할 때 호출됩니다.
+	 * <p>
+	 * Spring Security FilterChain에서 인증 실패 발생 시
+	 * 컨트롤러 진입 전에 본 메서드가 실행되며, HTTP 401 상태 코드와 함께
+	 * 서비스 공통 실패 응답 포맷을 JSON 형태로 반환합니다.
+	 * </p>
+	 *
+	 * @param request       인증 실패가 발생한 HTTP 요청
+	 * @param response      인증 실패 응답을 작성할 HTTP 응답
+	 * @param authException 인증 실패 원인에 대한 예외 정보
+	 * @throws IOException      응답 본문 작성 중 발생할 수 있는 예외
+	 * @throws ServletException 서블릿 처리 중 발생할 수 있는 예외
+	 */
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException, ServletException {
+
+		log.warn(
+			"인증 실패. requestURI={}, method={}, exception={}",
+			request.getRequestURI(),
+			request.getMethod(),
+			authException.getClass().getSimpleName()
+		);
+
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		GlobalErrorCode errorCode = GlobalErrorCode.UNAUTHORIZED;
+
+		ErrorResponse body = ErrorResponse.from(errorCode);
+
+		objectMapper.writeValue(response.getWriter(), body);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
@@ -1,0 +1,23 @@
+package com.github.sleeplessspecialist.peaktime.global.common.security.policy;
+
+/**
+ * 보안 경로 정책을 관리하는 클래스입니다.
+ * <p>
+ * Spring Security 설정에서 공개 API(permitAll)와
+ * 보호 API(authenticated)의 경계를 명확히 하기 위한 경로 정책 값을 한 곳에서 관리합니다.
+ * 초기 개발 단계에서는 모든 API를 허용하도록 설정하며, 이후 보안 정책 적용 시 보호가 필요한 경로만 점진적으로 분리합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 21.
+ */
+public final class SecurityPathPolicy {
+
+    /**
+     * 초기 개발 단계에서 모든 요청을 허용하기 위한 공개 API 경로 정책입니다.
+     */
+    public static final String[] PUBLIC_ENDPOINTS = { "/**" };
+
+	private SecurityPathPolicy() {}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
Closes #18 

---

## ✨ 작업 내용

- [x] 기능 추가
- Spring Security 기본 필터 체인(SecurityFilterChain) 구성
- 인증/인가 실패(401/403) 공통 핸들러 연결
- 초기 개발 단계에서 모든 요청을 허용(permitAll)하도록 설정
- 보안 경로 정책(SecurityPathPolicy) 분리로 확장 포인트 마련
---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. → 인증인가 구현이 완료된 이후 테스트 코드 대체할 예정입니다. 

---

## 💬 리뷰어에게
- 초기 개발 단계라 permitAll로 전체 오픈 상태입니다. 
  - 추후 SecurityPathPolicy 기반으로 보호 경로를 점진적으로 분리할 예정입니다.
