### PR TITLE
[feat] 강의 등록 API 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
@@ -1,0 +1,14 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.controller;
+
+/**
+ * CourseController 클래스입니다.
+ * <p>
+ * TODO: 클래스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public class CourseController {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
@@ -1,14 +1,44 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
+import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
 /**
- * CourseController 클래스입니다.
+ * 지식공유자(Lecturer) 관련 강의 관리 API를 제공하는 컨트롤러입니다.
  * <p>
- * TODO: 클래스의 역할을 작성하세요.
+ * 강의 등록, 수정, 삭제 및 지식공유자 본인의 강의 목록 조회 기능을 담당합니다.
+ * 모든 요청은 지식공유자 권한(ROLE_LECTURER)이 필요합니다.
  * </p>
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 1. 22.
  */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lecturer/courses")
 public class CourseController {
+
+	private final CourseService courseService;
+
+	/**
+	 * 신규 강의를 등록합니다.
+	 *
+	 * @param req 강의 등록 요청 정보 (제목, 설명, 가격 등)
+	 * @return 등록된 강의 ID를 포함한 응답 객체
+	 */
+	@PostMapping
+	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody CourseRegisterReq req) {
+		CourseRegisterRes response = courseService.registerCourse(req);
+		return ApiResponse.ok(response);
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
@@ -1,0 +1,34 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 강의 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
+ * <p>
+ * 제목, 설명, 카테고리, 가격, 썸네일 URL 정보를 포함합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseRegisterReq {
+
+	private String title;
+	private String description;
+	private String category;
+	private int price;
+	private String thumbnailUrl;
+
+	public CourseRegisterReq(String title, String description, String category, int price, String thumbnailUrl) {
+		this.title = title;
+		this.description = description;
+		this.category = category;
+		this.price = price;
+		this.thumbnailUrl = thumbnailUrl;
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterRes.java
@@ -1,0 +1,21 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 강의 등록 성공 시 반환되는 응답 DTO입니다.
+ * <p>
+ * 등록된 강의의 식별자(ID)를 클라이언트에게 전달하여,
+ * 이후 강의 상세 조회나 영상 업로드 요청 등에 사용할 수 있도록 합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Getter
+@AllArgsConstructor
+public class CourseRegisterRes {
+	private Long courseId;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -1,0 +1,14 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.entity;
+
+/**
+ * Course 클래스입니다.
+ * <p>
+ * TODO: 클래스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public class Course {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -49,7 +49,7 @@ public class Course {
 	private String category;
 
 	@Column(nullable = false)
-	private int price;
+	private BigDecimal price;
 
 	private String thumbnailUrl;
 

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -1,14 +1,74 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.entity;
 
+import java.time.LocalDateTime;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 /**
- * Course 클래스입니다.
+ * 강의 정보를 저장하는 엔티티 클래스입니다.
  * <p>
- * TODO: 클래스의 역할을 작성하세요.
+ * 데이터베이스의 'courses' 테이블과 매핑되며,
+ * 강의 제목, 설명, 가격, 썸네일 및 지식공유자 정보를 관리합니다.
  * </p>
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 1. 22.
  */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "courses")
 public class Course {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	@Column(nullable = false)
+	private String category;
+
+	@Column(nullable = false)
+	private int price;
+
+	private String thumbnailUrl;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "lecturer_id", nullable = false)
+	private User lecturer;
+
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	@Builder
+	public Course(String title, String description, String category, int price, String thumbnailUrl, User lecturer) {
+		this.title = title;
+		this.description = description;
+		this.category = category;
+		this.price = price;
+		this.thumbnailUrl = thumbnailUrl;
+		this.lecturer = lecturer;
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의(Course) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum입니다.
+ * <p>
+ * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CourseErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND("C001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+	UNAUTHORIZED_ACCESS("C002", "강의를 등록할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -1,0 +1,14 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.repository;
+
+/**
+ * CourseRepository 인터페이스입니다.
+ * <p>
+ * TODO: 인터페이스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public interface CourseRepository {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -1,14 +1,15 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+
 /**
- * CourseRepository 인터페이스입니다.
- * <p>
- * TODO: 인터페이스의 역할을 작성하세요.
- * </p>
+ * 강의(Course) 엔티티의 데이터베이스 접근 및 영속성 관리를 담당하는 리포지토리입니다.
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 1. 22.
  */
-public interface CourseRepository {
+public interface CourseRepository extends JpaRepository<Course, Long> {
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -1,0 +1,14 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.service;
+
+/**
+ * CourseService 클래스입니다.
+ * <p>
+ * TODO: 클래스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public class CourseService {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -1,14 +1,63 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
 /**
- * CourseService 클래스입니다.
+ * 강의 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
  * <p>
- * TODO: 클래스의 역할을 작성하세요.
+ * 강의 등록, 조회, 수정 등의 실질적인 데이터 처리 흐름을 제어합니다.
  * </p>
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 1. 22.
  */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CourseService {
+
+	private final CourseRepository courseRepository;
+	private final UserRepository userRepository;
+
+	/**
+	 * 새로운 강의를 생성하고 저장합니다.
+	 *
+	 * @param req 강의 등록에 필요한 상세 정보
+	 * @return 저장된 강의의 ID
+	 * @throws CustomException 사용자를 찾을 수 없거나 권한이 없는 경우 예외 발생
+	 */
+	@Transactional
+	public CourseRegisterRes registerCourse(CourseRegisterReq req) {
+		// TODO: 추후 SecurityContextHolder를 통해 로그인한 유저 ID를 가져오도록 수정 필요
+		Long mockUserId = 1L;
+
+		User lecturer = userRepository.findById(mockUserId)
+			.orElseThrow(() -> new CustomException(CourseErrorCode.USER_NOT_FOUND));
+
+		Course course = Course.builder()
+			.title(req.getTitle())
+			.description(req.getDescription())
+			.price(req.getPrice())
+			.category(req.getCategory())
+			.thumbnailUrl(req.getThumbnailUrl())
+			.lecturer(lecturer)
+			.build();
+
+		Course savedCourse = courseRepository.save(course);
+
+		return new CourseRegisterRes(savedCourse.getId());
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
@@ -1,0 +1,25 @@
+package com.github.sleeplessspecialist.peaktime.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * User 클래스입니다.
+ * <p>
+ * TODO: 클래스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Entity
+public class User {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
@@ -1,13 +1,19 @@
-package com.github.sleeplessspecialist.peaktime.domain.user;
+package com.github.sleeplessspecialist.peaktime.domain.user.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
- * User 클래스입니다.
+ * 사용자 정보를 관리하는 엔티티 클래스입니다.
  * <p>
- * TODO: 클래스의 역할을 작성하세요.
+ * 서비스의 모든 회원(지식공유자, 수강생) 정보를 저장하며,
+ * 강의 및 수강 신청 정보와 연관 관계를 맺습니다.
  * </p>
  *
  * @author 기섭
@@ -15,11 +21,19 @@ import jakarta.persistence.Id;
  * @since 2026. 1. 22.
  */
 @Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private String name;
+
+	// 테스트용 생성자 (필요 시 사용)
+	public User(String name) {
+		this.name = name;
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+
+/**
+ * UserRpository 인터페이스입니다.
+ * <p>
+ * TODO: 인터페이스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public interface UserRpository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
@@ -5,14 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 
 /**
- * UserRpository 인터페이스입니다.
+ * 사용자(User) 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
  * <p>
- * TODO: 인터페이스의 역할을 작성하세요.
+ * 회원 조회, 저장, 삭제 등의 기본적인 CRUD 기능을 제공합니다.
  * </p>
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 1. 22.
  */
-public interface UserRpository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #14

---

## ✨ 작업 내용
지식공유자(Lecturer)가 새로운 강의를 등록하는 API를 구현했습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

---

## 📸 스크린샷 
<img width="634" height="836" alt="스크린샷 2026-01-22 오전 11 16 02" src="https://github.com/user-attachments/assets/7d5948da-d48b-4a5c-aa5b-9ed02faaf322" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게
1. User 엔티티 관련
* 현재 User 도메인이 병합되기 전이라, `domain/user` 패키지에 임시 User 엔티티를 생성하여 작업했습니다.
* 추후 User 도메인 작업이 merge 되면 해당 의존성을 교체할 예정입니다.

2. 인증(Security) 관련
* 아직 Spring Security가 적용되지 않아, Service 로직에서 로그인한 유저 ID를 `1L`로 고정 해두었습니다.
* Security 설정이 완료되면 `SecurityContextHolder`에서 가져오도록 수정하겠습니다

3. 테스트 코드 관련
* 현재 기능 구현과 API 동작 확인(HTTP Request)을 우선적으로 진행했습니다.
* Service 및 Controller 계층의 자동화 테스트 코드(JUnit)는 이번 PR에 포함되지 않았으며, 추후 별도 이슈를 통해 보완할 예정입니다.