### PR TITLE
[feat] 강의 영상 업로드 API 구현 (AWS S3 연동)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     // AWS S3 연동을 위한 라이브러리 (Spring Cloud AWS v3)
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.9'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.asciidoctor.jvm.convert' version '4.0.5'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.9'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '4.0.5'
 }
 
 group = 'com.github.sleeplessspecialist'
@@ -10,56 +10,59 @@ version = '0.0.1-SNAPSHOT'
 description = 'Spring 1기 최종 프로젝트입니다. '
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	//testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    // AWS S3 연동을 위한 라이브러리 (Spring Cloud AWS v3)
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
+
 
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    dependsOn test
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
@@ -1,0 +1,52 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.service.LectureService;
+import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의 영상 관련 API 요청을 처리하는 컨트롤러입니다.
+ * <p>
+ * 특정 과정(Course) 하위에 영상을 업로드하거나 관리하는 기능을 제공합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/courses")
+public class LectureController {
+
+	private final LectureService lectureService;
+
+	/**
+	 * 강의 영상을 업로드하고 등록합니다.
+	 * <p>
+	 * `multipart/form-data` 형식을 사용하여 파일과 텍스트 데이터를 함께 전송받습니다.
+	 * </p>
+	 *
+	 * @param courseId 영상을 등록할 과정의 ID
+	 * @param req      업로드할 영상 파일과 제목 정보 (ModelAttribute 바인딩)
+	 * @return 등록된 강의 영상의 ID
+	 */
+	@PostMapping(value = "/{courseId}/lectures", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<Long> uploadLecture(
+		@PathVariable Long courseId,
+		@Valid @ModelAttribute LectureCreateReq req) {
+
+		Long lectureId = lectureService.createLecture(courseId, req);
+		return ApiResponse.ok(lectureId);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
@@ -47,6 +47,6 @@ public class LectureController {
 		@Valid @ModelAttribute LectureCreateReq req) {
 
 		Long lectureId = lectureService.createLecture(courseId, req);
-		return ApiResponse.ok(lectureId);
+		return ApiResponse.created(lectureId);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 강의 영상 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
+ * <p>
+ * 영상 제목(Text)과 실제 영상 파일(MultipartFile)을 포함하며,
+ * `multipart/form-data` 형식의 요청을 처리하기 위해 Setter가 포함되어 있습니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class LectureCreateReq {
+
+	@NotBlank(message = "강의 제목은 필수입니다.")
+	private String title;
+
+	@NotNull(message = "영상 파일은 필수입니다.")
+	private MultipartFile videoFile;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -22,6 +23,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class LectureCreateReq {
 
 	@NotBlank(message = "강의 제목은 필수입니다.")

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
@@ -1,0 +1,56 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.entity;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 개별 강의 영상 정보를 저장하는 엔티티 클래스입니다.
+ * <p>
+ * AWS S3에 업로드된 영상의 URL과 강의 제목을 관리하며,
+ * 하나의 과정(Course)에 여러 개의 강의 영상(Lecture)이 소속되는 N:1 구조를 가집니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "lectures")
+public class Lecture {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String videoUrl;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "course_id", nullable = false)
+	private Course course;
+
+	@Builder
+	public Lecture(String title, String videoUrl, Course course) {
+		this.title = title;
+		this.videoUrl = videoUrl;
+		this.course = course;
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
@@ -1,0 +1,33 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * LectureErrorCode 클래스입니다.
+ * <p>
+ * TODO: 클래스의 역할을 작성하세요.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 23.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum LectureErrorCode implements ErrorCode {
+
+	// L001: 확장자가 없거나 이상할 때
+	INVALID_FILE_EXTENSION("L001", "지원하지 않는 파일 형식입니다.", HttpStatus.BAD_REQUEST),
+
+	// L002: 파일 이름 자체가 비어있거나 문제 있을 때
+	INVALID_FILE_NAME("L002", "파일 이름이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/repository/LectureRepository.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
+
+/**
+ * 강의 영상(Lecture) 엔티티의 데이터베이스 접근 및 영속성 관리를 담당하는 리포지토리입니다.
+ * <p>
+ * 영상 정보의 조회, 저장, 삭제 등의 기본적인 CRUD 기능을 제공합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
@@ -1,18 +1,23 @@
 package com.github.sleeplessspecialist.peaktime.domain.lecture.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.exception.LectureErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.repository.LectureRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
 import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 강의 영상 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
@@ -25,6 +30,7 @@ import lombok.RequiredArgsConstructor;
  * @version 1.0
  * @since 2026. 1. 22.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LectureService {
@@ -32,6 +38,9 @@ public class LectureService {
 	private final LectureRepository lectureRepository;
 	private final CourseRepository courseRepository;
 	private final S3Uploader s3Uploader;
+
+	// 허용할 비디오 확장자 목록
+	private static final List<String> ALLOWED_VIDEO_EXTENSIONS = List.of("mp4", "avi", "mov", "wmv", "mkv");
 
 	/**
 	 * 특정 과정(Course)에 새로운 강의 영상을 등록합니다.
@@ -46,10 +55,21 @@ public class LectureService {
 		Course course = courseRepository.findById(courseId)
 			.orElseThrow(() -> new CustomException(GlobalErrorCode.INVALID_REQUEST));
 
+		// 파일 확장자 검증
+		validateVideoFileExtension(req.getVideoFile());
+
 		// S3 업로드 (폴더명: video)
 		String videoUrl = s3Uploader.upload(req.getVideoFile(), "video");
 
-		return saveLectureMetadata(course, req.getTitle(), videoUrl);
+		try {
+			// DB 저장 (별도 트랜잭션)
+			return saveLectureMetadata(course, req.getTitle(), videoUrl);
+		} catch (Exception e) {
+			// 보상 트랜잭션, DB 저장 실패 시 S3에 올라간 파일 삭제
+			log.error("DB 저장 실패로 인한 S3 파일 롤백 수행. url={}", videoUrl);
+			s3Uploader.deleteFile(videoUrl);
+			throw e;
+		}
 	}
 
 	/**
@@ -65,5 +85,24 @@ public class LectureService {
 			.build();
 
 		return lectureRepository.save(lecture).getId();
+	}
+
+	/**
+	 * 업로드된 파일의 확장자가 허용된 비디오 형식인지 검증함
+	 */
+	private void validateVideoFileExtension(MultipartFile file) {
+		String originalFilename = file.getOriginalFilename();
+
+		// 1. 파일명 자체가 문제가 있는 경우
+		if (originalFilename == null || !originalFilename.contains(".")) {
+			throw new CustomException(LectureErrorCode.INVALID_FILE_NAME);
+		}
+
+		String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+
+		// 2. 허용되지 않은 확장자인 경우
+		if (!ALLOWED_VIDEO_EXTENSIONS.contains(extension)) {
+			throw new CustomException(LectureErrorCode.INVALID_FILE_EXTENSION);
+		}
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
@@ -1,0 +1,69 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.service;
+
+import org.springframework.stereotype.Service;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.repository.LectureRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
+import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의 영상 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * <p>
+ * 전달받은 영상 파일을 S3에 업로드하고, 반환된 URL을 이용해
+ * Lecture 엔티티를 생성 및 저장하는 역할을 수행합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+
+	private final LectureRepository lectureRepository;
+	private final CourseRepository courseRepository;
+	private final S3Uploader s3Uploader;
+
+	/**
+	 * 특정 과정(Course)에 새로운 강의 영상을 등록합니다.
+	 * S3 업로드(네트워크 I/O)는 트랜잭션 외부에서 수행합니다.
+	 *
+	 * @param courseId 영상을 등록할 과정의 식별자 ID
+	 * @param req      영상 제목과 파일 데이터가 담긴 요청 객체
+	 * @return 저장된 강의 영상의 식별자 ID
+	 * @throws CustomException 과정이 존재하지 않거나 업로드에 실패한 경우 발생
+	 */
+	public Long createLecture(Long courseId, LectureCreateReq req) {
+		Course course = courseRepository.findById(courseId)
+			.orElseThrow(() -> new CustomException(GlobalErrorCode.INVALID_REQUEST));
+
+		// S3 업로드 (폴더명: video)
+		String videoUrl = s3Uploader.upload(req.getVideoFile(), "video");
+
+		return saveLectureMetadata(course, req.getTitle(), videoUrl);
+	}
+
+	/**
+	 * S3 업로드중엔 DB 트랜잭션이 일어나지 않아야함
+	 * 실제 DB 저장을 담당하는 트랜잭션 메서드
+	 */
+	@Transactional
+	public Long saveLectureMetadata(Course course, String title, String videoUrl) {
+		Lecture lecture = Lecture.builder()
+			.title(title)
+			.videoUrl(videoUrl)
+			.course(course)
+			.build();
+
+		return lectureRepository.save(lecture).getId();
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
@@ -58,6 +58,19 @@ public final class ApiResponse<T> {
 	}
 
 	/**
+	 * 리소스 생성 성공 응답 (201 Created)\
+	 */
+	public static <T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(
+			true,
+			SuccessCode.CREATED.getCode(),
+			SuccessCode.CREATED.getMessage(),
+			data,
+			LocalDateTime.now()
+		);
+	}
+
+	/**
 	 * 커스텀 성공 코드 (데이터 없음)
 	 */
 	public static <T> ApiResponse<T> of(SuccessCode successCode) {

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
@@ -24,7 +24,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessCode {
 
-	OK("S000", "OK");
+	OK("S000", "OK"),
+	CREATED("S001", "Created");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
@@ -1,0 +1,81 @@
+package com.github.sleeplessspecialist.peaktime.global.infra.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
+
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AWS S3 파일 업로드를 담당하는 유틸리티 클래스입니다.
+ * <p>
+ * Spring Cloud AWS의 S3Template을 사용하여 파일을 업로드하고,
+ * 업로드된 파일의 접근 가능한 URL을 반환합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+	private final S3Template s3Template;
+
+	@Value("${spring.cloud.aws.s3.bucket}")
+	private String bucket;
+
+	/**
+	 * 파일을 S3에 업로드합니다.
+	 *
+	 * @param file    업로드할 파일 (MultipartFile)
+	 * @param dirName S3 내부에 저장될 폴더 이름 (예: "video", "thumbnail")
+	 * @return 업로드된 파일의 전체 URL
+	 */
+	public String upload(MultipartFile file, String dirName) {
+		if (file.isEmpty()) {
+			throw new CustomException(GlobalErrorCode.INVALID_REQUEST);
+		}
+
+		// 1. 파일 이름 중복 방지를 위한 UUID 생성
+		String originalFilename = file.getOriginalFilename();
+		String uuid = UUID.randomUUID().toString();
+		String fileName = dirName + "/" + uuid + "_" + originalFilename;
+
+		try (InputStream inputStream = file.getInputStream()) {
+			// 2. S3에 파일 업로드 (Spring Cloud AWS 3.0 방식)
+			s3Template.upload(bucket, fileName, inputStream, ObjectMetadata.builder()
+				.contentType(file.getContentType())
+				.build());
+
+			log.info("S3 업로드 성공: {}", fileName);
+
+		} catch (IOException e) {
+			log.error("S3 업로드 실패: {}", e.getMessage());
+			throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+		}
+
+		// 3. 업로드된 파일의 접근 URL 반환
+		return getFileUrl(fileName);
+	}
+
+	/**
+	 * S3에 저장된 파일의 전체 URL을 가져옵니다.
+	 */
+	private String getFileUrl(String fileName) {
+		// ap-northeast-2 (서울) 기준 URL 형식
+		return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
@@ -2,6 +2,8 @@ package com.github.sleeplessspecialist.peaktime.global.infra.s3;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -77,5 +79,30 @@ public class S3Uploader {
 	private String getFileUrl(String fileName) {
 		// ap-northeast-2 (서울) 기준 URL 형식
 		return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
+	}
+
+	/**
+	 * S3에 저장된 파일을 삭제합니다.
+	 * (DB 저장 실패 시 롤백용, 혹은 파일 삭제 API용)
+	 *
+	 * @param fileUrl 삭제할 파일의 전체 URL (예: https://bucket.s3.../video/uuid_file.mp4)
+	 */
+	public void deleteFile(String fileUrl) {
+		try {
+			// 1. URL에서 파일 키(Key) 추출 (예: video/uuid_file.mp4)
+			String splitStr = ".com/";
+			String fileName = fileUrl.substring(fileUrl.lastIndexOf(splitStr) + splitStr.length());
+
+			// 2. 한글 파일명 등을 대비해 디코딩
+			String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+
+			// 3. S3에서 삭제
+			s3Template.deleteObject(bucket, decodedFileName);
+			log.info("S3 파일 삭제 성공: {}", decodedFileName);
+
+		} catch (Exception e) {
+			// 삭제 실패는 치명적인 에러로 보지 않고 로그만 남김 (나중에 배치로 지울 수도 있음)
+			log.error("S3 파일 삭제 실패: url={}, error={}", fileUrl, e.getMessage());
+		}
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,17 +21,36 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
-#  mail:
-#    host: smtp.gmail.com
-#    port: 587
-#    username: ${GMAIL_ID}
-#    password: ${SMTP_PASSWORD}
-#    properties:
-#      mail:
-#        smtp:
-#          auth: true
-#          starttls:
-#            enable: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_ID}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+  # 파일 업로드 용량 설정 (테스트 영상 업로드용 50MB)
+  # 실제 운영 환경에선 500MB로 늘릴 예정
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+
+  #AWS S3 설정
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+
 
 server:
   port: ${SERVER_PORT:8080}
@@ -46,4 +65,3 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   accessTokenExpirationMs: 3600000
   refreshTokenExpirationMs: 604800000
-


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #19

---

## ✨ 작업 내용
- [x] 기능 추가
강의(Course)에 영상(Lecture)을 등록하기 위한 **AWS S3 기반 파일 업로드 기능**을 구현했습니다.

**1. AWS S3 인프라 및 설정**
* `spring-cloud-aws-starter-s3` (v3.1.0) 의존성 추가
* `application.yml`: AWS 자격 증명 및 리전(ap-northeast-2) 설정, Multipart 파일 업로드 용량 제한 설정 (50MB)
* `S3Uploader`: `S3Template`을 활용한 파일 업로드 및 UUID 기반 파일명 생성 로직 구현

**2. Lecture 도메인 구현**
* **Entity:** `Lecture` 엔티티 생성 및 `Course`와 N:1 연관 관계 매핑
* **DTO:** `LectureCreateReq` (MultipartFile + Title) 구현
* **Repository:** 기본적인 CRUD 기능을 위한 `LectureRepository` 생성

**3. 비즈니스 로직 및 API**
* **Service:**
    * 요청받은 파일을 S3 `video` 디렉토리에 업로드
    * 반환된 S3 URL을 포함하여 `Lecture` 엔티티 저장
* **Controller:**
    * `POST /api/v1/courses/{courseId}/lectures`
    * `multipart/form-data` 요청 처리 (@ModelAttribute 사용)

---

## 📸 스크린샷 (선택)
<img width="822" height="901" alt="스크린샷 2026-01-22 오후 4 56 34" src="https://github.com/user-attachments/assets/62fac0dd-9416-481b-b6c9-8bbf17324160" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다. (S3에 저장되는 것 확인)
- [ ] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게
**1. 업로드 방식 (Proxy Upload)**
* 초기 개발 생산성을 위해 클라이언트가 서버로 파일을 보내고, 서버가 S3로 업로드하는 **Proxy 방식**을 채택했습니다.
* 추후 대용량 트래픽 발생 시 서버 부하를 줄이기 위해 **Presigned URL 방식**으로 고도화할 예정입니다. (TODO)

**2. 환경 변수 관리**
* AWS Access Key, Secret Key는 `application.yml`에 직접 노출하지 않고 환경 변수(`${AWS_...}`)로 분리하여 보안을 강화했습니다. 로컬 실행 시 환경 변수 설정이 필요합니다.