### PR TITLE
[feat] JWT 인증 필터 골격 구현 및 Security 설정 연동

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
@@ -6,7 +6,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.github.sleeplessspecialist.peaktime.global.common.security.filter.JwtAuthenticationFilter;
 import com.github.sleeplessspecialist.peaktime.global.common.security.handler.RestAccessDeniedHandler;
 import com.github.sleeplessspecialist.peaktime.global.common.security.handler.RestAuthenticationEntryPoint;
 import com.github.sleeplessspecialist.peaktime.global.common.security.policy.SecurityPathPolicy;
@@ -37,6 +39,7 @@ public class SecurityConfig {
 
 	private final RestAuthenticationEntryPoint authenticationEntryPoint;
 	private final RestAccessDeniedHandler accessDeniedHandler;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	/**
 	 * Spring Security 필터 체인을 정의합니다.
@@ -64,6 +67,8 @@ public class SecurityConfig {
 				.authenticationEntryPoint(authenticationEntryPoint)
 				.accessDeniedHandler(accessDeniedHandler)
 			)
+
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
 			.authorizeHttpRequests(auth -> auth
 				.anyRequest().permitAll()

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,128 @@
+package com.github.sleeplessspecialist.peaktime.global.common.security.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorResponse;
+import com.github.sleeplessspecialist.peaktime.global.common.security.jwt.JwtTokenErrorCode;
+import com.github.sleeplessspecialist.peaktime.global.common.security.jwt.JwtTokenException;
+import com.github.sleeplessspecialist.peaktime.global.common.security.jwt.JwtTokenProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 요청의 Authorization 헤더에서 JWT를 추출하여 검증하고,
+ * 유효한 경우 SecurityContext에 인증 정보를 설정하는 필터입니다.
+ *
+ * <p>
+ * 토큰이 없으면 인증을 설정하지 않고 다음 필터로 전달합니다.
+ * 토큰이 존재하지만 유효하지 않으면 401을 반환합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 22.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String token = extractToken(request);
+		if (token == null) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		try {
+			authenticate(request, token);
+			filterChain.doFilter(request, response);
+		} catch (JwtTokenException e) {
+			handleUnauthorized(response, e);
+			return;
+		}
+	}
+
+	/**
+	 * Authorization 헤더에서 Bearer 토큰을 추출합니다.
+	 */
+	private String extractToken(HttpServletRequest request) {
+		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+			return null;
+		}
+		return authorization.substring(BEARER_PREFIX.length()).trim();
+	}
+
+	/**
+	 * 토큰을 검증하고 SecurityContext에 인증 정보를 설정합니다.
+	 */
+	private void authenticate(HttpServletRequest request, String token) {
+		jwtTokenProvider.validateToken(token);
+
+		Long userId = jwtTokenProvider.getUserId(token);
+
+		List<GrantedAuthority> authorities = extractAuthorities(token);
+
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(userId, null, authorities);
+		authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	/**
+	 * 토큰의 role claim을 기반으로 권한 정보를 생성합니다.
+	 */
+	private List<GrantedAuthority> extractAuthorities(String token) {
+		String role = jwtTokenProvider.parseClaims(token).get("role", String.class);
+		if (role == null || role.isBlank()) {
+			return List.of();
+		}
+		return List.of(new SimpleGrantedAuthority(role));
+	}
+
+	/**
+	 * 인증 실패 시 JWT 에러코드에 맞춰 공통 ErrorResponse를 반환합니다.
+	 */
+	private void handleUnauthorized(
+		HttpServletResponse response,
+		JwtTokenException exception
+	) throws IOException {
+		SecurityContextHolder.clearContext();
+
+		JwtTokenErrorCode errorCode = exception.getErrorCode();
+		ErrorResponse errorResponse = ErrorResponse.from(errorCode);
+
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		objectMapper.writeValue(response.getWriter(), errorResponse);
+
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #21 
---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

- [x] 기능 추가
- AccessToken 기반 JWT 인증 필터(JwtAuthenticationFilter) 구현
- Authorization 헤더의 Bearer 토큰 검증 및 SecurityContext 설정
- JWT 검증 실패 시 공통 ErrorResponse 기반 401 응답 처리
- JwtAuthenticationFilter를 SecurityFilterChain에 연동
- 초기 개발 단계에서는 기능 개발 흐름을 위해 모든 요청을 permitAll로 설정

## 🧭 설계 참고사항
- 현재 단계에서는 인증(Authentication)만 처리하며, 인가(Authorization)는 이후 단계에서 확장 예정
- User 엔티티 및 로그인 도메인 도입 시 UserDetails 기반으로 확장 예정
---
## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. → 인가 기능 구현 완료 이후 테스트 코드 추가 수정예정입니다.

---

## 💬 리뷰어에게
전반적인 설계 구조와 인증 골격에 대해 확인 해주시면 감사 드리겠습니다.
해당 PR 이후 인가기반 설계 진행 및 최종 보완 작업 진행 예정입니다.