### PR TITLE
[feat] 커피챗 목록 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,9 @@ dependencies {
     // AWS S3 연동을 위한 라이브러리 (Spring Cloud AWS v3)
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
 
-
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/http/chat.http
+++ b/http/chat.http
@@ -7,3 +7,10 @@ Content-Type: application/json
 {
   "description": "안녕하세요"
 }
+
+### 채팅방 목록 조회 1
+GET {{host}}/api/v1/chat/room?page=0&size=5
+Accept: application/json
+### 채팅방 목록 조회 2
+GET {{host}}/api/v1/chat/room?page=0&size=10&sort=createdAt,ASC
+Accept: application/json

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/ChatController.java
@@ -1,5 +1,9 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomReq;
 import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomRes;
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.GetChatRoomListRes;
 import com.github.sleeplessspecialist.peaktime.domain.chat.service.ChatService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
@@ -38,10 +43,26 @@ public class ChatController {
 	 * 인증, 인가 미구현으로 임시 하드코딩
 	 */
 	@PostMapping("/room")
-	public ApiResponse<CreateChatRoomRes> createRoom(@RequestBody @Valid CreateChatRoomReq createChatRoomReq){
+	public ApiResponse<CreateChatRoomRes> createRoom(@RequestBody @Valid CreateChatRoomReq createChatRoomReq) {
 
 		Long userId = 1L;
 		CreateChatRoomRes response = chatService.createRoom(userId, createChatRoomReq);
-		return ApiResponse.of(SuccessCode.CREATED,response);
+		return ApiResponse.of(SuccessCode.CREATED, response);
+	}
+
+	/**
+	 * 채팅방 전체 조회 API
+	 * 인증 필요 X
+	 */
+	@GetMapping("/room")
+	public ApiResponse<GetChatRoomListRes> getRooms(
+		@PageableDefault(
+			size = 10,
+			sort = "createdAt",
+			direction = Sort.Direction.DESC
+		) Pageable pageable
+	) {
+		GetChatRoomListRes response = chatService.getChatRooms(pageable);
+		return ApiResponse.of(SuccessCode.OK, response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatRoomListItem.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatRoomListItem.java
@@ -1,0 +1,29 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * GetChatRoomListRes 의 부분 List 요소
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomListItem {
+
+	private Long roomId;
+	private ChatRoomStatus status;
+	private String description;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetChatRoomListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetChatRoomListRes.java
@@ -1,0 +1,43 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 커피쳇 방 목록 조회 응답 DTO입니다.
+ *
+ * <p>
+ * 페이지네이션이 적용된 커피쳇 방 목록을 반환하며,
+ * 각 페이지에 포함된 채팅방 정보와 함께 현재 페이지 번호,
+ * 페이지 크기, 전체 데이터 개수 및 전체 페이지 수를 포함합니다.
+ * </p>
+ *
+ * <p>
+ * 정렬 기준은 요청 시 전달된 {@code Pageable} 정보를 기반으로 하며,
+ * 기본적으로 생성일시(createdAt)를 기준으로 내림차순(DESC) 정렬됩니다.
+ * 페이지 번호는 0부터 시작하는 0-base index를 사용합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.23
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetChatRoomListRes {
+
+	private List<ChatRoomListItem> rooms;
+	private int page;
+	private int size;
+	private long totalElements;
+	private int totalPages;
+	private boolean hasNext;
+	private String sort;
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
@@ -24,7 +24,9 @@ public enum ChatErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("CHAT-001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
 	CHAT_ROOM_NOT_FOUND("CHAT-001", "존재하지 않는 채팅방입니다.", HttpStatus.NOT_FOUND),
-	UNAUTHORIZED_ACCESS("CHAT-002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN);
+	UNAUTHORIZED_ACCESS("CHAT-002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+	BAD_PAGING_CONDITION("CHAT-001", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
@@ -25,7 +25,7 @@ public enum ChatErrorCode implements ErrorCode {
 	USER_NOT_FOUND("CHAT-001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
 	CHAT_ROOM_NOT_FOUND("CHAT-001", "존재하지 않는 채팅방입니다.", HttpStatus.NOT_FOUND),
 	UNAUTHORIZED_ACCESS("CHAT-002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
-	BAD_PAGING_CONDITION("CHAT-001", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+	BAD_PAGING_CONDITION("CHAT-004", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
 
 	private final String code;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
@@ -1,8 +1,11 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
 
 /**
  * .
@@ -15,4 +18,9 @@ import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
  * @since
  */
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	/**
+	 * chatRoomStatus 를 제외한 상태 조회
+	 */
+	Page<ChatRoom> findByChatRoomStatusNot(ChatRoomStatus chatRoomStatus, Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
@@ -1,14 +1,21 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.chat.dto.ChatMessageReq;
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.ChatRoomListItem;
 import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomReq;
 import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomRes;
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.GetChatRoomListRes;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatMessage;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatParticipant;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.RoleInRoom;
 import com.github.sleeplessspecialist.peaktime.domain.chat.exception.ChatErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatMessageRepository;
@@ -21,10 +28,11 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
 import lombok.RequiredArgsConstructor;
 
 /**
- * .
- * <p>
+ * 커피쳇(Chat) 도메인의 핵심 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ *  *
+ *  <p>
  *
- * </p>
+ *  </p>
  *
  * @author 주우재
  * @version 1.0
@@ -104,6 +112,76 @@ public class ChatService {
 			.createdAt(chatRoom.getCreatedAt())
 			.updatedAt(chatRoom.getUpdatedAt())
 			.build();
+	}
+
+	/**
+	 * 커피쳇 방 목록을 페이지네이션과 정렬 조건에 따라 조회합니다.
+	 *
+	 * <p>
+	 * CLOSED 상태가 아닌 커피쳇 방을 대상으로 하며,
+	 * 요청된 {@link Pageable} 정보(page, size, sort)를 기준으로
+	 * 목록과 함께 페이지 메타데이터를 반환합니다.
+	 * </p>
+	 *
+	 * <p>
+	 * 조회 결과에는 현재 페이지 번호, 페이지 크기,
+	 * 전체 데이터 수, 전체 페이지 수, 다음 페이지 존재 여부 및
+	 * 적용된 정렬 기준이 포함됩니다.
+	 * </p>
+	 *
+	 * @param pageable 페이지 번호, 페이지 크기, 정렬 기준 정보
+	 * @return 페이지네이션이 적용된 커피쳇 방 목록 응답
+	 */
+	@Transactional(readOnly = true)
+	public GetChatRoomListRes getChatRooms(Pageable pageable) {
+
+		validatePageable(pageable);
+
+		Page<ChatRoom> roomPage =
+			chatRoomRepository.findByChatRoomStatusNot(ChatRoomStatus.CLOSED, pageable);
+
+		List<ChatRoomListItem> rooms = roomPage.getContent().stream()
+			.map(room -> ChatRoomListItem.builder()
+				.roomId(room.getId())
+				.status(room.getChatRoomStatus())
+				.description(room.getDescription())
+				.createdAt(room.getCreatedAt())
+				.build()
+			)
+			.toList();
+
+		return GetChatRoomListRes.builder()
+			.rooms(rooms)
+			.page(roomPage.getNumber())
+			.size(roomPage.getSize())
+			.totalElements(roomPage.getTotalElements())
+			.totalPages(roomPage.getTotalPages())
+			.hasNext(roomPage.hasNext())
+			.sort(roomPage.getSort().stream()
+				.map(order -> order.getProperty() + "," + order.getDirection())
+				.findFirst()
+				.orElse(null))
+			.build();
+	}
+
+	/**
+	 * 페이지 쿼리 파라미터 변수를 검증하는 메서드
+	 * 1. page > 0
+	 * 2. size >= 0 or size < 50 (정책)
+	 */
+	private void validatePageable(Pageable pageable) {
+
+		int page = pageable.getPageNumber();
+		int size = pageable.getPageSize();
+
+		if (page < 0) {
+			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
+		}
+
+		if (size < 1 || size > 50) {
+			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
+		}
+
 	}
 }
 


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #33 

---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

- [ ] 기능 추가
커피챗 목록 조회 API 를 구현. 
쿼리 파라미터로 페이징, 정렬 을 적용할수 있다.
- 정책에 의해서 ChatRoomStatus 가 closed 인 상태는 조회하지 않음.
- 인증이 없이도 허용하는 api 

---

## 📸 스크린샷 (선택)
<img width="640" height="675" alt="image" src="https://github.com/user-attachments/assets/9d03cf41-303f-4d02-82f1-e16ca4ded744" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
따끔한 피드백 좋아합니다. 감사합니다.
테스트 코드는 미구현 상태입니다. 