### PR TITLE
[feat] 커피챗 메시지 조회 API

### DIFF
--- a/http/message.http
+++ b/http/message.http
@@ -1,0 +1,11 @@
+### 메시지 조회 1
+@host = http://localhost:8080
+@roomId = 4
+
+GET {{host}}/api/v1/chat/room/{{roomId}}/messages?size=3
+Accept: application/json
+
+
+### 메시지 조회 2
+GET {{host}}/api/v1/chat/room/{{roomId}}/messages?size=3&lastId=3
+Accept: application/json

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/MessageController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/MessageController.java
@@ -1,0 +1,48 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.GetMessageListRes;
+import com.github.sleeplessspecialist.peaktime.domain.chat.service.MessageService;
+import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
+import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채팅방 메시지 조회 API를 제공하는 컨트롤러 클래스입니다.
+ * <p>
+ * 클라이언트로부터 채팅방 ID와 커서(lastId), 페이지 크기(size)를 전달받아
+ * 커서 기반 페이징 방식으로 메시지 목록을 조회하고, 표준 응답 형식({@link ApiResponse})으로 반환합니다.
+ * </p>
+ *
+ * <p>
+ * 실제 메시지 조회 로직은 {@link MessageService}에서 처리합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 26.
+ */
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+public class MessageController {
+
+	private final MessageService messageService;
+
+	@GetMapping("/room/{roomId}/messages")
+	public ApiResponse<GetMessageListRes> getMessages(
+		@PathVariable("roomId") Long roomId,
+		@RequestParam(required = false) Long lastId,
+		@RequestParam(required = false) int size
+	) {
+		Long userId = 1L;
+		GetMessageListRes response = messageService.findMessagePageByCursor(userId, roomId, lastId, size);
+		return ApiResponse.of(SuccessCode.OK, response);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatMessageListItem.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatMessageListItem.java
@@ -1,0 +1,48 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
+
+/**
+ * 채팅방 메시지 목록 조회 시 사용되는 응답용 DTO 클래스입니다.
+ * <p>
+ * {@link ChatMessage} 엔티티의 주요 정보를 클라이언트에 전달하기 위한 데이터 전송 객체로,
+ * 메시지 식별자, 발신자 정보, 메시지 내용, 읽음 여부 및 생성 시각을 포함합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 26.
+ */
+
+import java.time.LocalDateTime;
+
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatMessage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ChatMessageListItem {
+
+	private final Long messageId;
+	private final Long senderId;
+	private final String senderName;
+	private final String content;
+	private final boolean isRead;
+	private final LocalDateTime createAt;
+
+	public static ChatMessageListItem from(ChatMessage message) {
+		return ChatMessageListItem.builder()
+			.messageId(message.getId())
+			.senderId(message.getUser().getId())
+			.senderName(message.getUser().getName())
+			.content(message.getContent())
+			.isRead(message.isRead())
+			.createAt(message.getCreatedAt())
+			.build();
+	}
+}
+

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatRoomListItem.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/ChatRoomListItem.java
@@ -2,12 +2,14 @@ package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
 
 import java.time.LocalDateTime;
 
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * GetChatRoomListRes 의 부분 List 요소
@@ -17,13 +19,21 @@ import lombok.NoArgsConstructor;
  * @since
  */
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Builder
 public class ChatRoomListItem {
 
-	private Long roomId;
-	private ChatRoomStatus status;
-	private String description;
-	private LocalDateTime createdAt;
+	private final Long roomId;
+	private final ChatRoomStatus status;
+	private final String description;
+	private final LocalDateTime createdAt;
+
+	public static ChatRoomListItem from(ChatRoom chatRoom) {
+		return ChatRoomListItem.builder()
+			.roomId(chatRoom.getId())
+			.status(chatRoom.getChatRoomStatus())
+			.description(chatRoom.getDescription())
+			.createdAt(chatRoom.getCreatedAt())
+			.build();
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/CreateChatRoomRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/CreateChatRoomRes.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 채팅방 생성 응답 dto
@@ -17,15 +18,14 @@ import lombok.NoArgsConstructor;
  * @since 2026.01.22
  */
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Builder
 public class CreateChatRoomRes {
 
-	private Long roomId;
-	private Long userId;
-	private ChatRoomStatus chatRoomStatus;
-	private String description;
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
+	private final Long roomId;
+	private final Long userId;
+	private final ChatRoomStatus chatRoomStatus;
+	private final String description;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetChatRoomListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetChatRoomListRes.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 커피쳇 방 목록 조회 응답 DTO입니다.
@@ -27,17 +28,16 @@ import lombok.NoArgsConstructor;
  * @since 2026.01.23
  */
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Builder
 public class GetChatRoomListRes {
 
-	private List<ChatRoomListItem> rooms;
-	private int page;
-	private int size;
-	private long totalElements;
-	private int totalPages;
-	private boolean hasNext;
-	private String sort;
+	private final List<ChatRoomListItem> rooms;
+	private final int page;
+	private final int size;
+	private final long totalElements;
+	private final int totalPages;
+	private final boolean hasNext;
+	private final String sort;
 
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetMessageListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetMessageListRes.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채팅방 메시지 목록 조회 응답 dto
+ * <p>
+ * cursor-based-pagination 사용
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2025. 12. 22.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetMessageListRes {
+
+	private Long chatRoomId;
+	private int size;
+	private boolean hasNext;
+	private Long nextCursor;
+	private List<ChatMessageListItem> messageList;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetMessageListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/GetMessageListRes.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 채팅방 메시지 목록 조회 응답 dto
@@ -17,14 +18,13 @@ import lombok.NoArgsConstructor;
  * @since 2025. 12. 22.
  */
 @Getter
+@RequiredArgsConstructor
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class GetMessageListRes {
 
-	private Long chatRoomId;
-	private int size;
-	private boolean hasNext;
-	private Long nextCursor;
-	private List<ChatMessageListItem> messageList;
+	private final Long chatRoomId;
+	private final int size;
+	private final boolean hasNext;
+	private final Long nextCursor;
+	private final List<ChatMessageListItem> messageList;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
@@ -23,13 +23,14 @@ import lombok.RequiredArgsConstructor;
 public enum ChatErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("CHAT-001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	CHAT_ROOM_NOT_FOUND("CHAT-001", "존재하지 않는 채팅방입니다.", HttpStatus.NOT_FOUND),
-	UNAUTHORIZED_ACCESS("CHAT-002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+	CHAT_ROOM_NOT_FOUND("CHAT-002", "존재하지 않는 채팅방입니다.", HttpStatus.NOT_FOUND),
+	UNAUTHORIZED_ACCESS("CHAT-003", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
 	BAD_PAGING_CONDITION("CHAT-004", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 	CHAT_ROOM_NOT_OPEN("CHAT-005", "현재 참여할 수 없는 채팅방 상태입니다.", HttpStatus.CONFLICT),
-	ALREADY_PARTICIPANT("CHAT-006", "이미 해당 채팅방에 참여한 사용자입니다.", HttpStatus.CONFLICT);
+	ALREADY_PARTICIPANT("CHAT-006", "이미 해당 채팅방에 참여한 사용자입니다.", HttpStatus.CONFLICT),
+	INVALID_ROOM_ID("CHAT-007", "roomId 형식이 올바르지 않습니다.",HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;
 	private final HttpStatus httpStatus;
-}
+	}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
@@ -1,19 +1,44 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatMessage;
 
 /**
- * .
+ * 채팅 메시지 엔티티({@link ChatMessage})에 대한 데이터 접근을 담당하는 리포지토리 인터페이스입니다.
  * <p>
- *
+ * 커서 기반 페이징 방식을 사용하여 특정 채팅방의 메시지를 효율적으로 조회하는 기능을 제공합니다.
  * </p>
  *
  * @author 주우재
  * @version 1.0
- * @since
+ * @since 2026. 1. 26.
  */
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
+	/**
+	 * 채팅방의 메시지를 커서 기반으로 조회합니다.
+	 * <p>
+	 *  id 기준 내림차순(DESC) 정렬
+	 * 	lastId가 null이면 최신 메시지부터 조회
+	 * 	lastId가 있으면 해당 id보다 작은 메시지만 조회 (다음 페이지)
+	 * 	무한 스크롤용 Slice 페이징 지원
+	 * </p>
+	 */
+	@Query("""
+    SELECT m
+    FROM ChatMessage m
+    WHERE m.chatRoom.id = :roomId
+      AND (:lastId IS NULL OR m.id < :lastId)
+    ORDER BY m.id DESC""")
+	Slice<ChatMessage> findMessagesByCursor(
+		@Param("roomId") Long roomId,
+		@Param("lastId") Long lastId,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
@@ -32,7 +32,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 	 */
 	@Query("""
     SELECT m
-    FROM ChatMessage m
+    FROM ChatMessage m JOIN FETCH m.user
     WHERE m.chatRoom.id = :roomId
       AND (:lastId IS NULL OR m.id < :lastId)
     ORDER BY m.id DESC""")

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/MessageService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/MessageService.java
@@ -1,0 +1,128 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.ChatMessageListItem;
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.GetMessageListRes;
+import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatMessage;
+import com.github.sleeplessspecialist.peaktime.domain.chat.exception.ChatErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatMessageRepository;
+import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatParticipantRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채팅방 메시지 조회 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * <p>
+ * 커서 기반 페이징 방식을 사용하여 특정 채팅방의 메시지를 페이지 단위로 조회하며,
+ * 요청 파라미터에 대한 유효성 검증, 사용자 존재 여부 검증, 채팅방 접근 권한 검증을 수행합니다.
+ * </p>
+ *
+ * <p>
+ * 조회된 메시지는 {@link ChatMessageListItem} DTO로 변환되어 반환되며,
+ * 다음 페이지 조회를 위한 커서(nextCursor) 정보와 함께 응답 객체 {@link GetMessageListRes}로 구성됩니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 25.
+ */
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+	private static final int MIN_SIZE = 1;
+
+	private static final int MAX_SIZE = 50;
+
+	private final UserRepository userRepository;
+
+	private final ChatParticipantRepository chatParticipantRepository;
+
+	private final ChatMessageRepository chatMessageRepository;
+
+	/**
+	 * 1. roomId, lastId, size 값 유효성 검사
+	 * 2. userId 유효성 검사
+	 * 3. roomId 권한 검사
+	 * 4. 응답 dto 리턴
+	 */
+	@Transactional(readOnly = true)
+	public GetMessageListRes findMessagePageByCursor(Long userId, Long roomId, Long lastId, int size) {
+
+		validateRequest(roomId, lastId, size);
+
+		validateUser(userId);
+
+		validateAccess(roomId, userId);
+
+		Pageable pageable = PageRequest.of(0, size);
+
+		Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesByCursor(roomId, lastId, pageable);
+
+		List<ChatMessage> content = messageSlice.getContent();
+
+		List<ChatMessageListItem> messages = content.stream()
+			.map(ChatMessageListItem::from)
+			.toList();
+
+		Long nextCursor = calculateNextCursor(content, messageSlice.hasNext());
+
+		return GetMessageListRes.builder()
+			.chatRoomId(roomId)
+			.size(size)
+			.hasNext(messageSlice.hasNext())
+			.nextCursor(nextCursor)
+			.messageList(messages)
+			.build();
+	}
+
+	private void validateUser(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new CustomException(ChatErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	private void validateAccess(Long roomId, Long userId) {
+		boolean isParticipant = chatParticipantRepository.existsByChatRoomIdAndUserId(roomId, userId);
+		if (!isParticipant) {
+			throw new CustomException(ChatErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
+
+	/**
+	 *  cursor(lastId) 검증: null 허용, 값이 있으면 양수여야 함
+	 *  size 정책 (1~50)
+	 */
+	private void validateRequest(Long roomId, Long lastId, int size) {
+
+		if (roomId != null && roomId <= 0) {
+			throw new CustomException(ChatErrorCode.INVALID_ROOM_ID);
+		}
+
+		if (lastId != null && lastId <= 0) {
+			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
+		}
+
+		if (size < MIN_SIZE || size > MAX_SIZE) {
+			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
+		}
+	}
+	/**
+	 * 다음 페이지 커서(nextCursor) 계산
+	 */
+	private Long calculateNextCursor(List<ChatMessage> content, boolean hasNext) {
+		if (!hasNext || content.isEmpty()) {
+			return null;
+		}
+		return content.get(content.size() - 1).getId();
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #81 

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

- [x] 기능 추가
 - 커피챗 **메시지 조회 API** 구현 (커서 기반 페이징)
  - `lastId`(cursor) 가 `null` 인 경우 **최초 조회** 시나리오 지원
  - `Slice<T>` 기반 조회로 **countQuery 없이** 무한 스크롤 형태 지원
- 내부 로직
  - `MessageService` 추가 및 구현
    - 요청 파라미터 검증 로직 추가 (`roomId`, `lastId`, `size`)
    - 채팅방 접근 권한 검증 추가 (참가자 여부 체크)
    - 응답 DTO 구성 및 변환 로직 추가 (정적 팩토리 메서드 활용)
  - `ChatMessageRepository`에 커서 기반 JPQL 쿼리 메서드 작성
    - `id`가 클수록 최신 메시지라는 전제 하에 `id DESC` 정렬
    - `lastId`가 존재하면 `m.id < :lastId` 조건으로 다음 페이지 조회
- [x] 리펙토링
- 응답 dto 를 모두 캡슐화 했습니다.
---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
- 현재 인증/인가가 완전 구현 전이라, 메시지 조회 API에서 **userId를 임시 하드코딩** 처리한 부분이 있습니다.
- 커서 기반 페이징(Slice) 설계/쿼리 조건(`lastId IS NULL OR m.id < :lastId`) 및
  응답의 `nextCursor` 계산 로직에 대해 피드백 부탁드립니다.
  - createdAt 을 내림차순 정렬해야 하는것이 맞지만, id+createdAt 커서 방식을 써야 하므로 lastCreatedAt 를 쿼리 파라미터로 받아야 하는 번거로움이 있습니다.
  - 그래서 id 순서가 확실하게 먼저 만들어진 메시지라는 전제로 id 정렬만 적용했습니다.