### PR TITLE
[feat] 메시지 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/MessageController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/MessageController.java
@@ -2,6 +2,7 @@ package com.github.sleeplessspecialist.peaktime.domain.chat.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,18 +12,13 @@ import com.github.sleeplessspecialist.peaktime.domain.chat.service.MessageServic
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 채팅방 메시지 조회 API를 제공하는 컨트롤러 클래스입니다.
- * <p>
- * 클라이언트로부터 채팅방 ID와 커서(lastId), 페이지 크기(size)를 전달받아
- * 커서 기반 페이징 방식으로 메시지 목록을 조회하고, 표준 응답 형식({@link ApiResponse})으로 반환합니다.
- * </p>
- *
- * <p>
- * 실제 메시지 조회 로직은 {@link MessageService}에서 처리합니다.
- * </p>
+ * 채팅방 메시지 처리 API
  *
  * @author 주우재
  * @version 1.0
@@ -35,14 +31,35 @@ public class MessageController {
 
 	private final MessageService messageService;
 
+	/**
+	 * 메시지 전체 조회 API
+	 *
+	 * <p>
+	 *  클라이언트로부터 채팅방 ID와 커서(lastId), 페이지 크기(size)를 전달받아
+	 *  커서 기반 페이징 방식으로 메시지 목록을 조회하고, 표준 응답 형식({@link ApiResponse})으로 반환합니다.
+	 * </p>
+	 */
 	@GetMapping("/room/{roomId}/messages")
 	public ApiResponse<GetMessageListRes> getMessages(
-		@PathVariable("roomId") Long roomId,
-		@RequestParam(required = false) Long lastId,
-		@RequestParam(required = false) int size
+		@PathVariable @Positive Long roomId,
+		@RequestParam(required = false) @Positive Long lastId,
+		@RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
 	) {
 		Long userId = 1L;
 		GetMessageListRes response = messageService.findMessagePageByCursor(userId, roomId, lastId, size);
 		return ApiResponse.of(SuccessCode.OK, response);
 	}
+
+	/**
+	 * 메시지 읽음 처리 API
+	 */
+	@PostMapping("/room/{roomId}/read")
+	public ApiResponse<Void> readMessages(
+		@PathVariable @Positive Long roomId
+	) {
+		Long userId = 1L;
+		messageService.readAllMessages(userId, roomId);
+		return ApiResponse.ok();
+	}
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/exception/ChatErrorCode.java
@@ -27,8 +27,7 @@ public enum ChatErrorCode implements ErrorCode {
 	UNAUTHORIZED_ACCESS("CHAT-003", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
 	BAD_PAGING_CONDITION("CHAT-004", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 	CHAT_ROOM_NOT_OPEN("CHAT-005", "현재 참여할 수 없는 채팅방 상태입니다.", HttpStatus.CONFLICT),
-	ALREADY_PARTICIPANT("CHAT-006", "이미 해당 채팅방에 참여한 사용자입니다.", HttpStatus.CONFLICT),
-	INVALID_ROOM_ID("CHAT-007", "roomId 형식이 올바르지 않습니다.",HttpStatus.BAD_REQUEST);
+	ALREADY_PARTICIPANT("CHAT-006", "이미 해당 채팅방에 참여한 사용자입니다.", HttpStatus.CONFLICT);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.github.sleeplessspecialist.peaktime.domain.chat.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -31,14 +32,28 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 	 * </p>
 	 */
 	@Query("""
-    SELECT m
-    FROM ChatMessage m JOIN FETCH m.user
-    WHERE m.chatRoom.id = :roomId
-      AND (:lastId IS NULL OR m.id < :lastId)
-    ORDER BY m.id DESC""")
+		SELECT m
+		FROM ChatMessage m JOIN FETCH m.user
+		WHERE m.chatRoom.id = :roomId
+		  AND (:lastId IS NULL OR m.id < :lastId)
+		ORDER BY m.id DESC""")
 	Slice<ChatMessage> findMessagesByCursor(
 		@Param("roomId") Long roomId,
 		@Param("lastId") Long lastId,
 		Pageable pageable
 	);
+
+	/**
+	 * bulk update 를 이용하여 하나의 update 쿼리로 영속성 컨텍스트를 사용하지 않고
+	 * roomId 에 있는 모든 message 의 isRead 를 true 로 읽음 표시
+	 */
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		    UPDATE ChatMessage m
+		    SET m.isRead = true
+		    WHERE m.chatRoom.id = :roomId
+		      AND m.isRead = false
+		""")
+	void bulkReadAll(@Param("roomId") Long roomId);
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
@@ -204,7 +204,7 @@ public class ChatService {
 
 		validateUser(userId);
 
-		ChatRoom chatRoom = getChatRoom(userId);
+		ChatRoom chatRoom = getChatRoom(roomId);
 
 		validateHostPermission(roomId, userId);
 		chatRoom.close();

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
@@ -202,15 +202,16 @@ public class ChatService {
 	@Transactional
 	public void closeRoom(Long roomId, Long userId) {
 
-		ChatRoom chatRoom = getChatRoom(roomId);
-		User user = getUser(userId);
+		validateUser(userId);
+
+		ChatRoom chatRoom = getChatRoom(userId);
 
 		validateHostPermission(roomId, userId);
 		chatRoom.close();
 	}
 
 	/**
-	 * Room 이 DB 에 존재 하는지 검증
+	 * Room 이 DB 에 존재 하는지 검증 + 없다면 throw
 	 */
 	private ChatRoom getChatRoom(Long roomId) {
 		return chatRoomRepository.findById(roomId)
@@ -218,11 +219,20 @@ public class ChatService {
 	}
 
 	/**
-	 * User 가 DB 에 존재 하는지 검증
+	 * User 가 DB 에 존재 하는지 검증 + 없다면 throw
 	 */
 	private User getUser(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(ChatErrorCode.USER_NOT_FOUND));
+	}
+
+	/**
+	 * User 가 DB 에 존재 하는지 검증
+	 */
+	private void validateUser(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new CustomException(ChatErrorCode.USER_NOT_FOUND);
+		}
 	}
 
 	/**

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/MessageService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/MessageService.java
@@ -14,10 +14,12 @@ import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatMessage;
 import com.github.sleeplessspecialist.peaktime.domain.chat.exception.ChatErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatMessageRepository;
 import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatParticipantRepository;
+import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatRoomRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 채팅방 메시지 조회 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
@@ -35,32 +37,30 @@ import lombok.RequiredArgsConstructor;
  * @version 1.0
  * @since 2026. 1. 25.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MessageService {
-
-	private static final int MIN_SIZE = 1;
-
-	private static final int MAX_SIZE = 50;
 
 	private final UserRepository userRepository;
 
 	private final ChatParticipantRepository chatParticipantRepository;
 
 	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomRepository chatRoomRepository;
 
 	/**
-	 * 1. roomId, lastId, size 값 유효성 검사
-	 * 2. userId 유효성 검사
-	 * 3. roomId 권한 검사
+	 * 1. userId 유효성 검사
+	 * 2. roomId 유효성 검사
+	 * 3. user 의 room 에 대한 권한 검사
 	 * 4. 응답 dto 리턴
 	 */
 	@Transactional(readOnly = true)
 	public GetMessageListRes findMessagePageByCursor(Long userId, Long roomId, Long lastId, int size) {
 
-		validateRequest(roomId, lastId, size);
-
 		validateUser(userId);
+
+		validateRoom(roomId);
 
 		validateAccess(roomId, userId);
 
@@ -85,37 +85,50 @@ public class MessageService {
 			.build();
 	}
 
+	/**
+	 * 1. user 유효성 검사
+	 * 2. room 권한 검사
+	 * 3. user 의 room 에 대한 권한 검사
+	 * 4. roomId의 모든 메시지에서 isRead = True
+	 */
+	@Transactional
+	public void readAllMessages(Long userId, Long roomId) {
+
+		validateUser(userId);
+
+		validateRoom(roomId);
+
+		validateAccess(roomId, userId);
+
+		chatMessageRepository.bulkReadAll(roomId);
+	}
+
 	private void validateUser(Long userId) {
 		if (!userRepository.existsById(userId)) {
+			log.warn(" 존재하지 않는 사용자입니다. userId={}", userId);
 			throw new CustomException(ChatErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	private void validateRoom(Long roomId) {
+		if (!chatRoomRepository.existsById(roomId)) {
+			log.warn(" 존재하지 않는 채팅방입니다. roomId={}", roomId);
+			throw new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
 		}
 	}
 
 	private void validateAccess(Long roomId, Long userId) {
 		boolean isParticipant = chatParticipantRepository.existsByChatRoomIdAndUserId(roomId, userId);
 		if (!isParticipant) {
+			log.warn(
+				"채팅방 접근 권한이 없습니다. roomId={}, userId={}",
+				roomId, userId
+			);
 			throw new CustomException(ChatErrorCode.UNAUTHORIZED_ACCESS);
 		}
 	}
 
-	/**
-	 *  cursor(lastId) 검증: null 허용, 값이 있으면 양수여야 함
-	 *  size 정책 (1~50)
-	 */
-	private void validateRequest(Long roomId, Long lastId, int size) {
 
-		if (roomId != null && roomId <= 0) {
-			throw new CustomException(ChatErrorCode.INVALID_ROOM_ID);
-		}
-
-		if (lastId != null && lastId <= 0) {
-			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
-		}
-
-		if (size < MIN_SIZE || size > MAX_SIZE) {
-			throw new CustomException(ChatErrorCode.BAD_PAGING_CONDITION);
-		}
-	}
 	/**
 	 * 다음 페이지 커서(nextCursor) 계산
 	 */


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #35 

---

## ✨ 작업 내용
메시지 읽음 처리 API 구현 및 리펙토링 입니다.

- [x] 기능 추가

**메시지 읽음 처리 API 구현**
- 특정 채팅방의 읽지 않은 메시지를 bulk update 를 적용하여, 단일 UPDATE 쿼리로 일괄 읽음 처리.
- 메시지 개별 조회/수정 방식 대비 **DB 부하 감소**
- [x] 리팩토링

**메시지 조회 API 리팩토링 (MessageController)**
- 메시지 조회 파라미터에 **Bean Validation** 적용
- service 에 입력 형식 검증 로직 제외.

---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
* 처음에 page 관련 파라메터 검증 로직을 service 단에 헬퍼 메서드로 넣고, 커스텀 ErrorCode 로 예외를 던지는 형식으로 구현 했습니다.
컨벤션의 영역이지만, service 내부 구현이 지저분해지고, 코드가 많아 져서 요청 형식 에러는 모두 bean Validation 에 위임 했습니다.
* 최대한 모든 검증 로직에 log 를 찍으려고 하고 있습니다.
