### PR TITLE
[feat] JWT 인증 필터 완성 및 로그아웃 API 구현

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -23,12 +23,33 @@ Content-Type: {{contentType}}
 }
 
 > {%
-    // accessToken, refreshToken 저장
-    client.global.set("accessToken", response.body.accessToken);
-    client.global.set("refreshToken", response.body.refreshToken);
+    // accessToken, refreshToken 저장 (ApiResponse 래퍼의 data 하위)
+    client.global.set("accessToken", response.body.data.accessToken);
+    client.global.set("refreshToken", response.body.data.refreshToken);
 %}
 ### 2-1) (공개) 커피챗 전체 조회 - 토큰 없이 200이어야 함
-GET {{baseUrl}}/api/v1/chat/room?page=0&size=10&sort=createAt,ASC
+# sort 필드 오타(createAt)로 500이 날 수 있어 createdAt으로 고정
+GET {{baseUrl}}/api/v1/chat/room?page=0&size=10&sort=createdAt,DESC
+
+### 2-1-1) (공개) 커피챗 전체 조회(정렬 파라미터 없이) - 토큰 없이 200이어야 함
+GET {{baseUrl}}/api/v1/chat/room?page=0&size=10
+
+### 2-A) 로그아웃 (204) - RefreshToken 화이트리스트 삭제
+POST {{baseUrl}}/api/v1/auth/logout
+Content-Type: {{contentType}}
+
+{
+  "refreshToken": "{{refreshToken}}"
+}
+
+### 2-B) 로그아웃 이후 재발급 시도 - 401이어야 함(화이트리스트에서 삭제되었는지 간접 검증)
+POST {{baseUrl}}/api/v1/auth/refresh
+Content-Type: {{contentType}}
+
+{
+  "refreshToken": "{{refreshToken}}"
+}
+
 
 
 

--- a/http/auth.http
+++ b/http/auth.http
@@ -27,6 +27,12 @@ Content-Type: {{contentType}}
     client.global.set("accessToken", response.body.accessToken);
     client.global.set("refreshToken", response.body.refreshToken);
 %}
+### 2-1) (공개) 커피챗 전체 조회 - 토큰 없이 200이어야 함
+GET {{baseUrl}}/api/v1/chat/room?page=0&size=10&sort=createAt,ASC
+
+
+
+
 
 ### 3) 로그인 실패 (401) - 비밀번호 틀림
 POST {{baseUrl}}/api/v1/auth/login

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.auth.dto.request.LoginReq;
+import com.github.sleeplessspecialist.peaktime.domain.auth.dto.request.LogoutReq;
 import com.github.sleeplessspecialist.peaktime.domain.auth.dto.request.RefreshReq;
 import com.github.sleeplessspecialist.peaktime.domain.auth.dto.request.SignupReq;
 import com.github.sleeplessspecialist.peaktime.domain.auth.dto.response.LoginRes;
@@ -77,5 +78,26 @@ public class AuthController {
 	public ApiResponse<RefreshRes> refresh(@Valid @RequestBody RefreshReq request) {
 		final RefreshRes response = authService.refreshToken(request);
 		return ApiResponse.ok(response);
+	}
+
+	/**
+	 * 로그아웃을 수행합니다.
+	 *
+	 * <p>
+	 * 클라이언트로부터 전달받은 Refresh Token을 Redis 화이트리스트에서 삭제하여 이후 토큰 재발급을 차단합니다.
+	 * </p>
+	 *
+	 * <p>
+	 * Access Token은 Stateless(JWT) 특성상 서버에 저장되지 않으므로, 로그아웃 이후에도 만료 시점까지는 유효할 수 있습니다.
+	 * </p>
+	 *
+	 * @param request 로그아웃 대상 Refresh Token을 포함한 요청 DTO
+	 * @return 로그아웃 성공 시 204 No Content
+	 */
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(@Valid @RequestBody LogoutReq request) {
+		authService.logout(request.getRefreshToken());
+		return ApiResponse.noContent();
+
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/dto/request/LogoutReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/dto/request/LogoutReq.java
@@ -1,0 +1,25 @@
+package com.github.sleeplessspecialist.peaktime.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 로그아웃 요청 DTO입니다.
+ *
+ * <p>
+ * Redis 화이트리스트에서 삭제할 Refresh Token을 전달합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 27.
+ */
+@Getter
+@RequiredArgsConstructor
+public class LogoutReq {
+
+	@NotBlank(message = "refreshToken은 필수입니다.")
+	private final String refreshToken;
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/auth/service/AuthService.java
@@ -162,6 +162,25 @@ public class AuthService {
 		}
 	}
 
+	/**
+	 * Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.
+	 *
+	 * <p>
+	 * 전달받은 Refresh Token의 서명 및 만료 여부를 검증한 뒤,
+	 * Redis 화이트리스트에 등록된 토큰인지 확인합니다.
+	 * 검증이 완료되면 기존 Refresh Token을 폐기하고
+	 * 새로운 Access / Refresh Token을 발급합니다. (Refresh Token Rotation)
+	 * </p>
+	 *
+	 * <p>
+	 * 유효하지 않거나 화이트리스트에 존재하지 않는 Refresh Token은
+	 * 재발급이 허용되지 않습니다.
+	 * </p>
+	 *
+	 * @param request 재발급에 사용할 Refresh Token을 포함한 요청 DTO
+	 * @return 새로 발급된 Access / Refresh Token 정보
+	 * @throws CustomException 유효하지 않거나 만료된 Refresh Token인 경우
+	 */
 	public RefreshRes refreshToken(final RefreshReq request) {
 		final String refreshToken = request.getRefreshToken();
 
@@ -180,6 +199,27 @@ public class AuthService {
 		} catch (Exception e) {
 			throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
 		}
+	}
+
+	/**
+	 * Refresh Token 기반 로그아웃을 처리합니다.
+	 * <p>
+	 * 전달받은 Refresh Token 유효성 검증 이후 Redis 화이트리스트에서 해당 토큰을 삭제하여 토큰 재발급을 차단합니다.
+	 * Access Token은 Stateless(JWT) 특성상 서버에 저장되지 않으므로, 로그아웃 이후에도 만료 시점까지는 유효할 수 있습니다.
+	 * </p>
+	 *
+	 * @param refreshToken 로그아웃 대상 Refresh Token
+	 * @throws CustomException 유효하지 않은 Refresh Token 인 경우
+	 */
+	public void logout(final String refreshToken) {
+		validateRefreshToken(refreshToken);
+
+		final User user = validateUserByRefreshToken(refreshToken);
+		final Long userId = user.getId();
+
+		validateRefreshTokenWhitelisted(userId, refreshToken);
+
+		revokeRefreshTokenWhitelist(userId, refreshToken);
 	}
 
 	private User validateUserByRefreshToken(final String refreshToken) {

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/ApiResponse.java
@@ -71,7 +71,25 @@ public final class ApiResponse<T> {
 	}
 
 	/**
-	 * 커스텀 성공 코드 (데이터 없음)
+	 * 데이터가 없는 성공 응답 (204 No Content)
+	 *
+	 * <p>
+	 * 응답 바디를 포함하지 않는 성공 응답이 필요한 경우 사용합니다.
+	 * (예: 로그아웃, 상태 변경 API 등)
+	 * </p>
+	 */
+	public static <T> ApiResponse<T> noContent() {
+		return new ApiResponse<>(
+			true,
+			SuccessCode.NO_CONTENT.getCode(),
+			SuccessCode.NO_CONTENT.getMessage(),
+			null,
+			LocalDateTime.now()
+		);
+	}
+
+	/**
+	 * 커스텀 성공 코드 ( 데이터 없음)
 	 */
 	public static <T> ApiResponse<T> of(SuccessCode successCode) {
 		return new ApiResponse<>(

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/response/SuccessCode.java
@@ -25,7 +25,8 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessCode {
 
 	OK("S000", "OK"),
-	CREATED("S001", "CREATED");
+	CREATED("S001", "CREATED"),
+	NO_CONTENT("S002", "NO_CONTENT");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.github.sleeplessspecialist.peaktime.global.common.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,7 +19,7 @@ import com.github.sleeplessspecialist.peaktime.global.common.security.policy.Sec
 import lombok.RequiredArgsConstructor;
 
 /**
- * Spring Security의 기본 필터 체인을 구성하는 설정 클래스입니다.
+ * Spring Security 설정에서 사용하는 경로 정책을 정의합니다.
  *
  * <p>
  * 초기 개발 단계에서는 모든 요청을 허용하며,
@@ -72,8 +73,11 @@ public class SecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
 			.authorizeHttpRequests(auth -> auth
-				// 인증 엔드포인트는 공개
+				// 명세 기반 공개 엔드포인트 + 공개 조회(GET)는 permitAll
 				.requestMatchers(SecurityPathPolicy.PUBLIC_ENDPOINTS).permitAll()
+				.requestMatchers(HttpMethod.GET, SecurityPathPolicy.PUBLIC_GET_ENDPOINTS).permitAll()
+				.requestMatchers(SecurityPathPolicy.ADMIN_ENDPOINTS).hasRole("ADMIN")
+				.requestMatchers(SecurityPathPolicy.LECTURER_ENDPOINTS).hasRole("LECTURER")
 				// 그 외는 인증 필요
 				.anyRequest().authenticated()
 			);

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
@@ -101,11 +101,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	 * 토큰의 role claim을 기반으로 권한 정보를 생성합니다.
 	 */
 	private List<GrantedAuthority> extractAuthorities(String token) {
-		String role = jwtTokenProvider.parseClaims(token).get("role", String.class);
+		String role = jwtTokenProvider.getRole(token);
 		if (role == null || role.isBlank()) {
 			return List.of();
 		}
-		return List.of(new SimpleGrantedAuthority(role));
+		return List.of(new SimpleGrantedAuthority("ROLE_" + role));
 	}
 
 	/**

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/jwt/JwtTokenErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/jwt/JwtTokenErrorCode.java
@@ -28,15 +28,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum JwtTokenErrorCode implements ErrorCode {
 
-	EXPIRED("JWT_001", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
-	INVALID_SIGNATURE("JWT_002", "토큰 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
-	MALFORMED("JWT_003", "토큰 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-	UNSUPPORTED("JWT_004", "지원하지 않는 토큰 형식입니다.", HttpStatus.UNAUTHORIZED),
-	EMPTY("JWT_005", "토큰이 비어있습니다.", HttpStatus.UNAUTHORIZED),
-	INVALID("JWT_006", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
-	INVALID_SUBJECT("JWT_007", "토큰 subject(userId) 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-	INVALID_SECRET("JWT_008", "JWT secret 설정이 올바른 Base64 형식이 아닙니다. "
-		+ "설정 값(jwt.secret 또는 환경변수 JWT_SECRET_KEY)을 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+	EXPIRED("JWT001", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	INVALID_SIGNATURE("JWT002", "토큰 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+	MALFORMED("JWT003", "토큰 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+	UNSUPPORTED("JWT004", "지원하지 않는 토큰 형식입니다.", HttpStatus.UNAUTHORIZED),
+	EMPTY("JWT005", "토큰이 비어있습니다.", HttpStatus.UNAUTHORIZED),
+	INVALID("JWT006", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	INVALID_SUBJECT("JWT007", "토큰 subject(userId) 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+	INVALID_SECRET("JWT008", "JWT secret 설정이 올바른 Base64 형식이 아닙니다. "
+		+ "설정 값(jwt.secret 또는 환경변수 JWT_SECRET_KEY)을 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+	MISSING_ROLE("JWT009", "토큰 role Claim이 누락되었습니다.", HttpStatus.UNAUTHORIZED);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/jwt/JwtTokenProvider.java
@@ -131,6 +131,25 @@ public class JwtTokenProvider {
         }
     }
 
+    /**
+     * Access Token에 포함된 role Claim 값을 반환합니다.
+     * <p>
+     * role Claim은 Access Token 전용이며, Refresh Token에는 포함되지 않습니다.
+     * </p>
+     *
+     * @param token JWT 문자열
+     * @return role 문자열 (예: ROLE_ADMIN, ROLE_LECTURER, ROLE_STUDENT)
+     * @throws JwtTokenException role Claim이 누락된 경우
+     */
+    public String getRole(String token) {
+        String role = parseClaims(token).get(CLAIM_ROLE, String.class);
+        if (role == null || role.isBlank()) {
+            throw new JwtTokenException(JwtTokenErrorCode.MISSING_ROLE);
+        }
+        return role;
+    }
+
+
     private String requireToken(String token) {
         if (token == null || token.isBlank()) {
             throw new JwtTokenException(JwtTokenErrorCode.EMPTY);

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
@@ -1,12 +1,11 @@
 package com.github.sleeplessspecialist.peaktime.global.common.security.policy;
 
 /**
- * 보안 경로 정책을 관리하는 클래스입니다.
+ * Spring Security 설정에서 사용하는 경로 정책을 정의합니다.
+ *
  * <p>
- * Spring Security 설정에서 공개 API(permitAll)와
- * 보호 API(authenticated)의 경계를 명확히 하기 위한 경로 정책 값을 한 곳에서 관리합니다.
- * 현재는 기능 개발 병행을 위해 전체 API를 공개(permitAll)로 두되,
- * 이후 인증/인가 적용 시 공개 경로(/api/v1/auth/** 등)와 보호 경로를 점진적으로 분리합니다.
+ * 명세 기준으로 비로그인 허용(permitAll) 범위와
+ * 역할(ROLE) 기반 보호 경로를 한 곳에서 관리합니다.
  * </p>
  *
  * @author 재원
@@ -18,23 +17,43 @@ public final class SecurityPathPolicy {
 	/**
 	 * 공개(permitAll) 엔드포인트 목록입니다.
 	 * <p>
-	 * 현재는 기능 개발 병행을 위해 전체 API를 공개 처리합니다. ("/**")
-	 * 이후 단계에서 아래 {@link #AUTH_ENDPOINTS} 등으로 좁혀갈 예정입니다.
+	 * 인증/인가(비로그인 가능)
 	 * </p>
 	 */
-	public static final String[] PUBLIC_ENDPOINTS = {"/**"};
+	public static final String[] PUBLIC_ENDPOINTS = {
+		"/error",
+
+		// 인증/인가(비로그인 가능)
+		"/api/v1/auth/signup",
+		"/api/v1/auth/login",
+		"/api/v1/auth/refresh",
+		"/api/v1/auth/logout",
+		"/api/v1/auth/password/**",
+
+		// OAuth 시작/콜백
+		"/api/v1/oauth2/**"
+	};
 
 	/**
-	 * 인증 관련 엔드포인트 목록입니다.
+	 * 공개 조회(GET) 엔드포인트 목록입니다.
 	 * <p>
-	 * 인가 적용 단계에서 공개 경로를 아래 목록으로 축소하는 것을 기본값으로 가정합니다.
+	 * 명세에서 "공통(비로그인)"으로 정의된 조회 API만 포함합니다.
+	 * (중요) POST/PATCH/DELETE까지 열리지 않도록 SecurityConfig에서 HttpMethod.GET와 함께 사용해야 합니다.
 	 * </p>
 	 */
-	public static final String[] AUTH_ENDPOINTS = {
-		"/api/v1/auth/login",
-		"/api/v1/auth/signup",
-		"/api/v1/auth/**"
+	public static final String[] PUBLIC_GET_ENDPOINTS = {
+		"/api/v1/courses",
+		"/api/v1/courses/*",
+		"/api/v1/reviews",
+		"/api/v1/reviews/*",
+		"/api/v1/chat/room" // 커피챗 전체 조회(비로그인)
 	};
+
+	// 관리자
+	public static final String ADMIN_ENDPOINTS = "/api/v1/admin/**";
+
+	// 강의자
+	public static final String LECTURER_ENDPOINTS = "/api/v1/lecturer/**";
 
 	private SecurityPathPolicy() {
 	}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #29 
- close #87 
---

## ✨ 작업 내용
JWT 인증 필터를 완성하고, API 명세 기준으로 공개/보호 경계를 정리했습니다.
또한 로그아웃 및 토큰 재발급 흐름까지 포함하여,
IntelliJ auth.http를 통해 인증/인가 전반을 빠르게 점검할 수 있도록 구성했습니다.

- [x] 기능 추가
- [x] 리팩토링

1. JWT 인증 필터 연동 및 SecurityContext 설정
- JwtAuthenticationFilter에서 Authorization 헤더의 Bearer 토큰을 추출
- AccessToken 유효성 검증 후 SecurityContext에 Authentication 저장
- 토큰 예외 발생 시 401(ErrorResponse) 반환

2. JwtTokenProvider 책임 정리(캡슐화)
- role claim 추출 로직을 JwtTokenProvider로 이동하여 필터의 책임 축소
- claim 구조 변경 시 Provider 레벨에서만 수정 가능하도록 정리

3. JWT 에러코드 확장
- role claim 누락 케이스 대응을 위해 JwtTokenErrorCode에 에러코드 추가 (MISSING_ROLE)

4. SecurityConfig 공개/보호 경계 명세 반영
- SecurityPathPolicy 기반으로 공개 엔드포인트를 명세 기준으로 분리
- 공개 조회는 GET 메서드에 한해 permitAll 적용 (PUBLIC_GET_ENDPOINTS)
- /api/v1/admin/** → ADMIN, /api/v1/lecturer/** → LECTURER 인가 규칙 적용
- 그 외 요청은 authenticated로 보호

5. 로그아웃 및 토큰 흐름 점검용 HTTP 스모크 테스트 추가
- auth.http에 로그인 / 로그아웃 / 토큰 재발급 요청을 추가
- ApiResponse 래퍼 구조에 맞게 토큰 파싱 경로 수정
- 로그아웃 이후 RefreshToken 재사용 시 401 반환 여부를 통해
Redis 화이트리스트 삭제를 간접적으로 검증
---

## 📸 스크린샷 (선택)
<img width="650" height="606" alt="image" src="https://github.com/user-attachments/assets/2f93f23f-e251-4f94-8015-d3163aa77cd3" />
<img width="696" height="562" alt="image" src="https://github.com/user-attachments/assets/14fc3a0d-154f-4002-88d4-1b8ec21e787f" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
- 공개 조회 경로를 PUBLIC_GET_ENDPOINTS로 분리하여 쓰기(PATCH/DELETE/POST)가 열리지 않도록 설계했습니다.
  - 이후 기능 구현 시, 명세에 맞는 조회 Path를 해당 목록에 추가하여 사용하면 됩니다.
- role claim 값과 hasRole() 매칭을 위해 authority 포맷(ROLE prefix) 정책이 일관되게 적용되어 있는지 확인 부탁드립니다.
- 로그아웃은 RefreshToken을 Redis 화이트리스트에서 삭제하여
이후 토큰 재발급을 차단하는 방식으로 구현했습니다.