### PR TITLE
[feat] 강의 상세 조회 API 구현

### DIFF
--- a/http/course.http
+++ b/http/course.http
@@ -1,0 +1,37 @@
+### 변수 설정
+@host = http://localhost:8080
+@courseId = 1
+
+### 1. 강의 생성
+POST {{host}}/api/v1/courses
+Content-Type: application/json
+
+{
+  "title": "스프링 부트 완벽 정복",
+  "description": "이 강의 하나면 실무 투입 가능합니다.",
+  "category": "BACKEND",
+  "price": 55000,
+  "thumbnailUrl": "https://via.placeholder.com/600x400"
+}
+
+### 2. 강의 영상 업로드 (Multipart)
+# 주의: http 폴더(이 파일과 같은 위치)에 'test-video.mp4' 파일이 있어야 동작합니다.
+POST {{host}}/api/v1/courses/{{courseId}}/lectures
+Content-Type: multipart/form-data; boundary=WebAppBoundary
+
+--WebAppBoundary
+Content-Disposition: form-data; name="title"
+Content-Type: text/plain
+
+1강. 오리엔테이션
+
+--WebAppBoundary
+Content-Disposition: form-data; name="videoFile"; filename="test-video.mp4"
+Content-Type: video/mp4
+
+< ./test-video.mp4
+--WebAppBoundary--
+
+### 3. 강의 상세 조회
+GET {{host}}/api/v1/lecturer/courses/{{courseId}}
+Accept: application/json

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
@@ -1,10 +1,13 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
@@ -38,7 +41,24 @@ public class CourseController {
 	 */
 	@PostMapping
 	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody CourseRegisterReq req) {
+
 		CourseRegisterRes response = courseService.registerCourse(req);
+		return ApiResponse.ok(response);
+	}
+
+	/**
+	 * 강의 상세 정보를 조회합니다.
+	 * <p>
+	 * 접근 권한: 누구나 가능 (비로그인 포함)
+	 * </p>
+	 *
+	 * @param courseId 조회할 강의 ID
+	 * @return 강의 상세 정보 (커리큘럼 포함, 영상 URL 제외)
+	 */
+	@GetMapping("/{courseId}")
+	public ApiResponse<CourseDetailRes> getCourseDetail(@PathVariable Long courseId) {
+
+		CourseDetailRes response = courseService.getCourseDetail(courseId);
 		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseDetailRes.java
@@ -1,0 +1,35 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의 상세 조회 응답 DTO입니다.
+ * <p>
+ * 강의 기본 정보와 지식공유자(Lecturer) 정보, 커리큘럼(Curriculum)을 포함합니다.
+ * 모든 필드는 private final로 선언되어 불변성을 보장합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.1
+ * @since 2026. 1. 27.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CourseDetailRes {
+
+	private final Long courseId;
+	private final String title;
+	private final String description;
+	private final BigDecimal price;
+	private final String thumbnailUrl;
+	private final Double ratingAvg;
+	private final Integer reviewCount;
+	private final LecturerDto lecturer;
+	private final List<CurriculumDto> curriculum;
+	private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
@@ -3,7 +3,7 @@ package com.github.sleeplessspecialist.peaktime.domain.course.dto;
 import java.math.BigDecimal;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * 강의 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
@@ -16,12 +16,13 @@ import lombok.RequiredArgsConstructor;
  * @since 2026. 1. 22.
  */
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class CourseRegisterReq {
 
-	private final String title;
-	private final String description;
-	private final String category;
-	private final BigDecimal price;
-	private final String thumbnailUrl;
+	private String title;
+	private String description;
+	private String category;
+	private BigDecimal price;
+	private String thumbnailUrl;
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CurriculumDto.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CurriculumDto.java
@@ -1,0 +1,23 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * CurriculumDto 클래스입니다.
+ * <p>
+ * 강의 상세 조회 시 포함되는 커리큘럼(강의 영상 목차) 정보 DTO입니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 27.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CurriculumDto {
+
+	private final Long lectureId;
+	private final String title;
+	private final Integer duration;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/LecturerDto.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/LecturerDto.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의 상세 조회 시 포함되는 지식공유자(Lecturer) 정보 DTO입니다.
+ * <p>
+ * 이전의 Tutor라는 명칭을 제거하고 Lecturer로 통일했습니다.
+ * </p>
+ */
+@Getter
+@RequiredArgsConstructor
+public class LecturerDto {
+
+	private final Long lecturerId;
+	private final String name;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -1,10 +1,14 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.entity;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,21 +25,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 강의 정보를 저장하는 엔티티 클래스입니다.
+ * 강의(강좌) 정보를 저장하는 엔티티 클래스입니다.
  * <p>
- * 데이터베이스의 'courses' 테이블과 매핑되며,
- * 강의 제목, 설명, 가격, 썸네일 및 지식공유자 정보를 관리합니다.
+ * 강의 제목, 설명, 가격, 썸네일 및 지식공유자(Lecturer) 정보를 관리합니다.
+ * 하나의 강의는 여러 개의 개별 영상(Lecture)을 가집니다.
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "courses")
-public class Course {
+public class Course extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,12 +59,18 @@ public class Course {
 
 	private String thumbnailUrl;
 
+	@Column(nullable = false)
+	private Double ratingAvg = 0.0;
+
+	@Column(nullable = false)
+	private Integer reviewCount = 0;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "lecturer_id", nullable = false)
 	private User lecturer;
 
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
+	@OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Lecture> lectures = new ArrayList<>();
 
 	@Builder
 	public Course(String title, String description, String category, BigDecimal price, String thumbnailUrl,
@@ -70,7 +81,5 @@ public class Course {
 		this.price = price;
 		this.thumbnailUrl = thumbnailUrl;
 		this.lecturer = lecturer;
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
@@ -22,7 +22,8 @@ import lombok.RequiredArgsConstructor;
 public enum CourseErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("C001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	UNAUTHORIZED_ACCESS("C002", "강의를 등록할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+	UNAUTHORIZED_ACCESS("C002", "강의를 등록할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+	COURSE_NOT_FOUND("C003", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -1,6 +1,10 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 
@@ -12,4 +16,14 @@ import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
  * @since 2026. 1. 22.
  */
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+	/**
+	 * 강의 ID로 강의 상세 정보를 조회합니다.
+	 * 지식공유자(lecturer)와 커리큘럼(lectures) 정보를 한 번의 쿼리로 함께 가져옵니다
+	 */
+	@Query("SELECT c FROM Course c " +
+		"JOIN FETCH c.lecturer " +
+		"LEFT JOIN FETCH c.lectures " +
+		"WHERE c.id = :courseId")
+	Optional<Course> findByIdWithDetail(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -1,10 +1,16 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CurriculumDto;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.LecturerDto;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
@@ -21,7 +27,7 @@ import lombok.RequiredArgsConstructor;
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @Service
@@ -59,5 +65,47 @@ public class CourseService {
 		Course savedCourse = courseRepository.save(course);
 
 		return new CourseRegisterRes(savedCourse.getId());
+	}
+
+	/**
+	 * 강의 상세 정보를 조회합니다.
+	 * <p>
+	 * 강의 기본 정보뿐만 아니라 지식공유자(Lecturer) 정보와
+	 * 커리큘럼(Lecture List)을 함께 반환합니다.
+	 * </p>
+	 *
+	 * @param courseId 조회할 강의 ID
+	 * @return 강의 상세 응답 DTO (Curriculum 포함)
+	 */
+	public CourseDetailRes getCourseDetail(Long courseId) {
+
+		Course course = courseRepository.findByIdWithDetail(courseId)
+			.orElseThrow(() -> new CustomException(CourseErrorCode.COURSE_NOT_FOUND));
+
+		LecturerDto lecturerDto = new LecturerDto(
+			course.getLecturer().getId(),
+			course.getLecturer().getName()
+		);
+
+		List<CurriculumDto> curriculumList = course.getLectures().stream()
+			.map(lecture -> new CurriculumDto(
+				lecture.getId(),
+				lecture.getTitle(),
+				lecture.getDuration()
+			))
+			.collect(Collectors.toList());
+
+		return new CourseDetailRes(
+			course.getId(),
+			course.getTitle(),
+			course.getDescription(),
+			course.getPrice(),
+			course.getThumbnailUrl(),
+			course.getRatingAvg(),
+			course.getReviewCount(),
+			lecturerDto,
+			curriculumList,
+			course.getUpdatedAt()
+		);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
@@ -5,7 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * 강의 영상 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
@@ -19,12 +19,13 @@ import lombok.RequiredArgsConstructor;
  * @since 2026. 1. 22.
  */
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class LectureCreateReq {
 
 	@NotBlank(message = "강의 제목은 필수입니다.")
-	private final String title;
+	private String title;
 
 	@NotNull(message = "영상 파일은 필수입니다.")
-	private final MultipartFile videoFile;
+	private MultipartFile videoFile;
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
@@ -1,6 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.lecture.entity;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,19 +20,19 @@ import lombok.NoArgsConstructor;
 /**
  * 개별 강의 영상 정보를 저장하는 엔티티 클래스입니다.
  * <p>
- * AWS S3에 업로드된 영상의 URL과 강의 제목을 관리하며,
- * 하나의 과정(Course)에 여러 개의 강의 영상(Lecture)이 소속되는 N:1 구조를 가집니다.
+ * 영상의 제목, URL, 재생 시간(Duration)을 관리하며
+ * 특정 Course(강좌)에 소속됩니다.
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "lectures")
-public class Lecture {
+public class Lecture extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,14 +44,18 @@ public class Lecture {
 	@Column(nullable = false)
 	private String videoUrl;
 
+	@Column(nullable = false)
+	private Integer duration;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "course_id", nullable = false)
 	private Course course;
 
 	@Builder
-	public Lecture(String title, String videoUrl, Course course) {
+	public Lecture(String title, String videoUrl, Integer duration, Course course) {
 		this.title = title;
 		this.videoUrl = videoUrl;
+		this.duration = (duration != null) ? duration : 0;
 		this.course = course;
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/CourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/CourseServiceTest.java
@@ -1,0 +1,110 @@
+package com.github.sleeplessspecialist.peaktime.domain.course;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+/**
+ * CourseService 비즈니스 로직 테스트 클래스입니다.
+ * <p>
+ * 대상 클래스: CourseService
+ * 주요 기능: 강의 등록, 강의 상세 조회
+ * </p>
+ *
+ * @author 기섭
+ * @since 2026. 1. 27.
+ */
+@ExtendWith(MockitoExtension.class) // Mockito 환경 사용
+class CourseServiceTest {
+
+	@InjectMocks
+	private CourseService courseService;
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Test
+	@DisplayName("성공: 강의 ID로 상세 정보를 조회하면, CourseDetailRes DTO가 반환된다.")
+	void getCourseDetail_Success() {
+		// given
+		// 1. 강사(Lecturer) 생성 (Reflection으로 ID 주입)
+		User lecturer = User.createForSignup("김스프링", "test@test.com", "hash", "01012345678");
+		ReflectionTestUtils.setField(lecturer, "id", 1L);
+
+		// 2. 강의(Course) 생성
+		Course course = Course.builder()
+			.title("스프링 완전 정복")
+			.description("설명")
+			.category("BACKEND")
+			.price(BigDecimal.valueOf(50000))
+			.thumbnailUrl("thumb.jpg")
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", 100L);
+
+		// 3. 커리큘럼(Lecture) 생성 및 추가
+		Lecture lecture1 = Lecture.builder().title("1강 OT").duration(600).course(course).build();
+		Lecture lecture2 = Lecture.builder().title("2강 개요").duration(1200).course(course).build();
+
+		// Entity의 lectures 리스트에 수동으로 추가 (테스트 환경이므로)
+		course.getLectures().add(lecture1);
+		course.getLectures().add(lecture2);
+
+		// 4. Mocking: Repository 호출 시 위에서 만든 course 반환
+		given(courseRepository.findByIdWithDetail(100L)).willReturn(Optional.of(course));
+
+		// when
+		CourseDetailRes result = courseService.getCourseDetail(100L);
+
+		// then
+		// 1. 강의 기본 정보 검증
+		assertThat(result.getCourseId()).isEqualTo(100L);
+		assertThat(result.getTitle()).isEqualTo("스프링 완전 정복");
+
+		// 2. 지식공유자(Lecturer) 정보 검증 (Tutor -> Lecturer 용어 변경 반영 확인)
+		assertThat(result.getLecturer().getLecturerId()).isEqualTo(1L);
+		assertThat(result.getLecturer().getName()).isEqualTo("김스프링");
+
+		// 3. 커리큘럼(Lecture) 정보 검증
+		assertThat(result.getCurriculum()).hasSize(2);
+		assertThat(result.getCurriculum().get(0).getTitle()).isEqualTo("1강 OT");
+		assertThat(result.getCurriculum().get(0).getDuration()).isEqualTo(600);
+
+		// 4. 호출 여부 검증
+		verify(courseRepository).findByIdWithDetail(100L);
+	}
+
+	@Test
+	@DisplayName("실패: 존재하지 않는 강의 ID 조회 시 COURSE_NOT_FOUND 예외가 발생한다.")
+	void getCourseDetail_Fail_NotFound() {
+		// given
+		Long invalidCourseId = 999L;
+		given(courseRepository.findByIdWithDetail(invalidCourseId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> courseService.getCourseDetail(invalidCourseId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(CourseErrorCode.COURSE_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #23 

---

## ✨ 작업 내용
로그인 여부와 관계없이 접근 가능한 강의 상세 조회 기능을 구현했습니다.

- [x] 기능 추가
**강의 상세 조회 API 구현 (`GET /api/v1/lecturer/courses/{courseId}`)**
* **보안 데이터 처리:** 영상의 실제 재생 URL(`videoUrl`)은 응답에서 제외하고, 메타데이터(제목, 시간)만 반환하도록 DTO를 구성했습니다.
* **Unit Test:** `CourseServiceTest`를 작성하여 Mockito 기반으로 DB 연결 없이 비즈니스 로직(DTO 변환, 예외 처리)을 검증했습니다.
* **API Test:** IntelliJ HTTP Client를 활용한 `http/course.http` 통합 테스트 스크립트를 추가했습니다.


---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. 

---

## 💬 리뷰어에게
API 테스트(`http` 파일) 시 DB에 초기 데이터가 없으면 404/500 에러가 발생할 수 있습니다. 아래 SQL을 실행 후 테스트 부탁드립니다.
```sql
-- 테스트용 강사(User) 및 강의(Course) 데이터
INSERT INTO users (name, email, password_hash, phone_number, point, role, status, created_at, updated_at)
VALUES ('김스프링', 'test@test.com', 'hash', '01000000000', 0, 'LECTURER', 'ACTIVE', NOW(), NOW());

INSERT INTO courses (title, description, category, price, rating_avg, review_count, lecturer_id, created_at, updated_at)
VALUES ('스프링 정복', '설명', 'BACKEND', 50000, 0.0, 0, 1, NOW(), NOW());