### PR TITLE
[feat] 강의 목록 조회 API 구현

### DIFF
--- a/http/course.http
+++ b/http/course.http
@@ -33,5 +33,10 @@ Content-Type: video/mp4
 --WebAppBoundary--
 
 ### 3. 강의 상세 조회
-GET {{host}}/api/v1/lecturer/courses/{{courseId}}
+GET {{host}}/api/v1/courses/{{courseId}}
+Accept: application/json
+
+### 4. 강의 전체 목록 조회 (페이징)
+# page=0 (첫 페이지), size=5 (5개씩 조회)
+GET {{host}}/api/v1/courses?page=0&size=5
 Accept: application/json

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
@@ -1,12 +1,14 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
@@ -14,6 +16,7 @@ import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -29,6 +32,7 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/v1/courses")
 public class CourseController {
 
@@ -38,18 +42,22 @@ public class CourseController {
 	 * 강의 목록 조회 API
 	 * <p>
 	 * 페이징 기능을 제공하며, 기본적으로 최신순(created_at DESC)으로 정렬됩니다.
-	 * 예: /api/v1/courses?page=0&size=10
+	 * page와 size를 명시적으로 받아서 검증(@Min)을 수행합니다.
+	 * 클라이언트는 1페이지부터 요청한다고 가정하고, 서버에서는 0페이지로 변환합니다.
 	 * </p>
 	 *
-	 * @param pageable 페이징 정보 (자동 주입)
 	 * @return 페이징된 강의 목록
 	 */
 	@GetMapping
 	public ApiResponse<Page<CourseListRes>> getCourseList(
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+		@RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") int page,
+		@RequestParam(defaultValue = "10") @Min(value = 1, message = "사이즈는 1 이상이어야 합니다.") int size
 	) {
 
+		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
 		Page<CourseListRes> response = courseService.getCourseList(pageable);
+
 		return ApiResponse.ok(response);
 	}
 

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/CourseController.java
@@ -1,48 +1,55 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
-import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
-import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * 지식공유자(Lecturer) 관련 강의 관리 API를 제공하는 컨트롤러입니다.
+ * 강의(Course) 조회 API 컨트롤러입니다.
  * <p>
- * 강의 등록, 수정, 삭제 및 지식공유자 본인의 강의 목록 조회 기능을 담당합니다.
- * 모든 요청은 지식공유자 권한(ROLE_LECTURER)이 필요합니다.
+ * 강의 목록 조회 및 상세 조회 기능을 제공하며,
+ * 인증 여부와 관계없이 누구나 접근 가능합니다.
  * </p>
  *
  * @author 기섭
  * @version 1.0
- * @since 2026. 1. 22.
+ * @since 2026. 1. 27.
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/lecturer/courses")
+@RequestMapping("/api/v1/courses")
 public class CourseController {
 
 	private final CourseService courseService;
 
 	/**
-	 * 신규 강의를 등록합니다.
+	 * 강의 목록 조회 API
+	 * <p>
+	 * 페이징 기능을 제공하며, 기본적으로 최신순(created_at DESC)으로 정렬됩니다.
+	 * 예: /api/v1/courses?page=0&size=10
+	 * </p>
 	 *
-	 * @param req 강의 등록 요청 정보 (제목, 설명, 가격 등)
-	 * @return 등록된 강의 ID를 포함한 응답 객체
+	 * @param pageable 페이징 정보 (자동 주입)
+	 * @return 페이징된 강의 목록
 	 */
-	@PostMapping
-	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody CourseRegisterReq req) {
+	@GetMapping
+	public ApiResponse<Page<CourseListRes>> getCourseList(
+		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
 
-		CourseRegisterRes response = courseService.registerCourse(req);
+		Page<CourseListRes> response = courseService.getCourseList(pageable);
 		return ApiResponse.ok(response);
 	}
 

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
-import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
+import com.github.sleeplessspecialist.peaktime.domain.course.service.LecturerCourseService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
 import jakarta.validation.Valid;
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/lecturer/courses")
 public class LecturerCourseController {
 
-	private final CourseService courseService;
+	private final LecturerCourseService LecturerCourseService;
 
 	/**
 	 * 신규 강의를 등록합니다.
@@ -39,7 +39,7 @@ public class LecturerCourseController {
 	@PostMapping
 	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody @Valid CourseRegisterReq req) {
 
-		CourseRegisterRes response = courseService.registerCourse(req);
+		CourseRegisterRes response = LecturerCourseService.registerCourse(req);
 		return ApiResponse.created(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
@@ -1,0 +1,45 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
+import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 지식공유자(Lecturer) 전용 강의 관리 API 컨트롤러입니다.
+ * <p>
+ * 강의 등록, 수정, 삭제 등 지식공유자 권한(ROLE_LECTURER)이 필요한 기능을 담당합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 27.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lecturer/courses")
+public class LecturerCourseController {
+
+	private final CourseService courseService;
+
+	/**
+	 * 신규 강의를 등록합니다.
+	 *
+	 * @param req 강의 등록 요청 정보 (제목, 설명, 가격 등)
+	 * @return 등록된 강의 ID를 포함한 응답 객체
+	 */
+	@PostMapping
+	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody @Valid CourseRegisterReq req) {
+
+		CourseRegisterRes response = courseService.registerCourse(req);
+		return ApiResponse.created(response);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import java.math.BigDecimal;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강의 목록 조회 응답 DTO입니다.
+ * <p>
+ * 리스트 형태이므로 커리큘럼 같은 상세 정보는 제외하고,
+ * 썸네일, 제목, 가격, 강사명 등 요약 정보만 포함합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 27.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CourseListRes {
+
+	private final Long courseId;
+	private final String title;
+	private final String description;
+	private final String category;
+	private final BigDecimal price;
+	private final String thumbnailUrl;
+	private final Double ratingAvg;
+	private final Integer reviewCount;
+	private final String lecturerName;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -4,9 +4,8 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 
@@ -20,21 +19,18 @@ import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
 	/**
-	 * 강의 ID로 강의 상세 정보를 조회합니다.
-	 * 지식공유자(lecturer)와 커리큘럼(lectures) 정보를 한 번의 쿼리로 함께 가져옵니다
+	 * 강의 상세 조회
+	 * @EntityGraph를 사용하여 Lecturer(강사)와 Lectures(커리큘럼)를 한 번에 가져옵니다.
 	 */
-	@Query("SELECT c FROM Course c " +
-		"JOIN FETCH c.lecturer " +
-		"LEFT JOIN FETCH c.lectures " +
-		"WHERE c.id = :courseId")
-	Optional<Course> findByIdWithDetail(@Param("courseId") Long courseId);
+	@Override
+	@EntityGraph(attributePaths = {"lecturer", "lectures"})
+	Optional<Course> findById(Long id);
 
 	/**
-	 * 강의 목록을 페이징하여 조회합니다.
-	 * N+1 문제를 방지하기 위해 Lecturer(지식공유자)를 Fetch Join 합니다.
-	 * * countQuery: 페이징을 위해서는 전체 개수를 세는 쿼리가 별도로 필요합니다.
+	 * 강의 목록 조회 (페이징)
+	 * @EntityGraph를 사용하여 Lecturer(강사) 정보만 함께 가져옵니다.
 	 */
-	@Query(value = "SELECT c FROM Course c JOIN FETCH c.lecturer",
-		countQuery = "SELECT COUNT(c) FROM Course c")
-	Page<Course> findAllWithLecturer(Pageable pageable);
+	@Override
+	@EntityGraph(attributePaths = {"lecturer"})
+	Page<Course> findAll(Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -2,6 +2,8 @@ package com.github.sleeplessspecialist.peaktime.domain.course.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +28,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 		"LEFT JOIN FETCH c.lectures " +
 		"WHERE c.id = :courseId")
 	Optional<Course> findByIdWithDetail(@Param("courseId") Long courseId);
+
+	/**
+	 * 강의 목록을 페이징하여 조회합니다.
+	 * N+1 문제를 방지하기 위해 Lecturer(지식공유자)를 Fetch Join 합니다.
+	 * * countQuery: 페이징을 위해서는 전체 개수를 세는 쿼리가 별도로 필요합니다.
+	 */
+	@Query(value = "SELECT c FROM Course c JOIN FETCH c.lecturer",
+		countQuery = "SELECT COUNT(c) FROM Course c")
+	Page<Course> findAllWithLecturer(Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -10,15 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
-import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
-import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CurriculumDto;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.LecturerDto;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
-import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
-import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 import lombok.RequiredArgsConstructor;
@@ -39,36 +35,6 @@ import lombok.RequiredArgsConstructor;
 public class CourseService {
 
 	private final CourseRepository courseRepository;
-	private final UserRepository userRepository;
-
-	/**
-	 * 새로운 강의를 생성하고 저장합니다.
-	 *
-	 * @param req 강의 등록에 필요한 상세 정보
-	 * @return 저장된 강의의 ID
-	 * @throws CustomException 사용자를 찾을 수 없거나 권한이 없는 경우 예외 발생
-	 */
-	@Transactional
-	public CourseRegisterRes registerCourse(CourseRegisterReq req) {
-		// TODO: 추후 SecurityContextHolder를 통해 로그인한 유저 ID를 가져오도록 수정 필요
-		Long mockUserId = 1L;
-
-		User lecturer = userRepository.findById(mockUserId)
-			.orElseThrow(() -> new CustomException(CourseErrorCode.USER_NOT_FOUND));
-
-		Course course = Course.builder()
-			.title(req.getTitle())
-			.description(req.getDescription())
-			.price(req.getPrice())
-			.category(req.getCategory())
-			.thumbnailUrl(req.getThumbnailUrl())
-			.lecturer(lecturer)
-			.build();
-
-		Course savedCourse = courseRepository.save(course);
-
-		return new CourseRegisterRes(savedCourse.getId());
-	}
 
 	/**
 	 * 강의 상세 정보를 조회합니다.
@@ -80,10 +46,8 @@ public class CourseService {
 	 * @param courseId 조회할 강의 ID
 	 * @return 강의 상세 응답 DTO (Curriculum 포함)
 	 */
-	@Transactional(readOnly = true)
 	public CourseDetailRes getCourseDetail(Long courseId) {
-
-		Course course = courseRepository.findByIdWithDetail(courseId)
+		Course course = courseRepository.findById(courseId)
 			.orElseThrow(() -> new CustomException(CourseErrorCode.COURSE_NOT_FOUND));
 
 		LecturerDto lecturerDto = new LecturerDto(
@@ -119,10 +83,8 @@ public class CourseService {
 	 * @param pageable 페이징 정보 (page, size, sort)
 	 * @return 페이징된 강의 목록 DTO
 	 */
-	@Transactional(readOnly = true)
 	public Page<CourseListRes> getCourseList(Pageable pageable) {
-
-		Page<Course> coursePage = courseRepository.findAllWithLecturer(pageable);
+		Page<Course> coursePage = courseRepository.findAll(pageable);
 
 		return coursePage.map(course -> new CourseListRes(
 			course.getId(),

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -3,10 +3,13 @@ package com.github.sleeplessspecialist.peaktime.domain.course.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CurriculumDto;
@@ -107,5 +110,28 @@ public class CourseService {
 			curriculumList,
 			course.getUpdatedAt()
 		);
+	}
+
+	/**
+	 * 강의 전체 목록을 페이징하여 조회합니다.
+	 *
+	 * @param pageable 페이징 정보 (page, size, sort)
+	 * @return 페이징된 강의 목록 DTO
+	 */
+	public Page<CourseListRes> getCourseList(Pageable pageable) {
+
+		Page<Course> coursePage = courseRepository.findAllWithLecturer(pageable);
+
+		return coursePage.map(course -> new CourseListRes(
+			course.getId(),
+			course.getTitle(),
+			course.getDescription(),
+			course.getCategory(),
+			course.getPrice(),
+			course.getThumbnailUrl(),
+			course.getRatingAvg(),
+			course.getReviewCount(),
+			course.getLecturer().getName()
+		));
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -80,6 +80,7 @@ public class CourseService {
 	 * @param courseId 조회할 강의 ID
 	 * @return 강의 상세 응답 DTO (Curriculum 포함)
 	 */
+	@Transactional(readOnly = true)
 	public CourseDetailRes getCourseDetail(Long courseId) {
 
 		Course course = courseRepository.findByIdWithDetail(courseId)
@@ -118,6 +119,7 @@ public class CourseService {
 	 * @param pageable 페이징 정보 (page, size, sort)
 	 * @return 페이징된 강의 목록 DTO
 	 */
+	@Transactional(readOnly = true)
 	public Page<CourseListRes> getCourseList(Pageable pageable) {
 
 		Page<Course> coursePage = courseRepository.findAllWithLecturer(pageable);

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -1,0 +1,63 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * LecturerCourseService 클래스입니다.
+ * <p>
+ * 지식공유자(Lecturer) 전용 강의 관리 서비스입니다.
+ * 강의 등록, 수정, 삭제 등의 비즈니스 로직을 담당합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+@Service
+@RequiredArgsConstructor
+public class LecturerCourseService {
+
+	private final CourseRepository courseRepository;
+	private final UserRepository userRepository;
+
+	/**
+	 * 새로운 강의를 생성하고 저장합니다.
+	 *
+	 * @param req 강의 등록에 필요한 상세 정보
+	 * @return 저장된 강의의 ID
+	 * @throws CustomException 사용자를 찾을 수 없거나 권한이 없는 경우 예외 발생
+	 */
+	@Transactional
+	public CourseRegisterRes registerCourse(CourseRegisterReq req) {
+		// TODO: 추후 SecurityContextHolder를 통해 로그인한 유저 ID를 가져오도록 수정 필요
+		Long mockUserId = 1L;
+
+		User lecturer = userRepository.findById(mockUserId)
+			.orElseThrow(() -> new CustomException(CourseErrorCode.USER_NOT_FOUND));
+
+		Course course = Course.builder()
+			.title(req.getTitle())
+			.description(req.getDescription())
+			.price(req.getPrice())
+			.category(req.getCategory())
+			.thumbnailUrl(req.getThumbnailUrl())
+			.lecturer(lecturer)
+			.build();
+
+		Course savedCourse = courseRepository.save(course);
+
+		return new CourseRegisterRes(savedCourse.getId());
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
@@ -45,7 +45,7 @@ public class Lecture extends BaseTimeEntity {
 	private String videoUrl;
 
 	@Column(nullable = false)
-	private Integer duration;
+	private Integer duration = 0;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "course_id", nullable = false)

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/CourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/CourseServiceTest.java
@@ -1,10 +1,11 @@
 package com.github.sleeplessspecialist.peaktime.domain.course;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
@@ -106,5 +112,57 @@ class CourseServiceTest {
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(CourseErrorCode.COURSE_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("성공: 강의 목록을 페이징하여 조회하면, CourseListRes Page가 반환된다.")
+	void getCourseList_Success() {
+		// given
+		// 1. 페이징 요청 객체 생성 (0페이지, 10개씩)
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// 2. 강사 및 강의 데이터 생성
+		User lecturer = User.createForSignup("이자바", "java@test.com", "hash", "01011112222");
+
+		Course course1 = Course.builder()
+			.title("자바의 정석")
+			.description("기초")
+			.category("BACKEND")
+			.price(BigDecimal.valueOf(10000))
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course1, "id", 1L);
+
+		Course course2 = Course.builder()
+			.title("JPA 프로그래밍")
+			.description("심화")
+			.category("BACKEND")
+			.price(BigDecimal.valueOf(20000))
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course2, "id", 2L);
+
+		// 3. Mock Page 객체 생성 (DB에서 반환될 예상 결과)
+		List<Course> courseList = List.of(course1, course2);
+		Page<Course> mockPage = new PageImpl<>(courseList, pageable, 2);
+
+		// 4. Mocking: Repository 호출 시 mockPage 반환
+		given(courseRepository.findAllWithLecturer(any(Pageable.class))).willReturn(mockPage);
+
+		// when
+		Page<CourseListRes> result = courseService.getCourseList(pageable);
+
+		// then
+		// 1. 페이지 크기 및 내용 검증
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getTotalElements()).isEqualTo(2);
+
+		// 2. 데이터 매핑 검증 (Entity -> DTO 변환 확인)
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo("자바의 정석");
+		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("이자바"); // 강사 이름 확인
+		assertThat(result.getContent().get(1).getPrice()).isEqualTo(BigDecimal.valueOf(20000));
+
+		// 3. 호출 검증
+		verify(courseRepository).findAllWithLecturer(any(Pageable.class));
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseServiceTest.java
@@ -1,4 +1,4 @@
-package com.github.sleeplessspecialist.peaktime.domain.course;
+package com.github.sleeplessspecialist.peaktime.domain.course.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -25,22 +25,21 @@ import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
-import com.github.sleeplessspecialist.peaktime.domain.course.service.CourseService;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 /**
- * CourseService 비즈니스 로직 테스트 클래스입니다.
+ * CourseService(조회 전용) 비즈니스 로직 테스트 클래스입니다.
  * <p>
  * 대상 클래스: CourseService
- * 주요 기능: 강의 등록, 강의 상세 조회
+ * 주요 기능: 강의 상세 조회, 강의 목록 조회
  * </p>
  *
  * @author 기섭
  * @since 2026. 1. 27.
  */
-@ExtendWith(MockitoExtension.class) // Mockito 환경 사용
+@ExtendWith(MockitoExtension.class)
 class CourseServiceTest {
 
 	@InjectMocks
@@ -52,12 +51,11 @@ class CourseServiceTest {
 	@Test
 	@DisplayName("성공: 강의 ID로 상세 정보를 조회하면, CourseDetailRes DTO가 반환된다.")
 	void getCourseDetail_Success() {
+
 		// given
-		// 1. 강사(Lecturer) 생성 (Reflection으로 ID 주입)
 		User lecturer = User.createForSignup("김스프링", "test@test.com", "hash", "01012345678");
 		ReflectionTestUtils.setField(lecturer, "id", 1L);
 
-		// 2. 강의(Course) 생성
 		Course course = Course.builder()
 			.title("스프링 완전 정복")
 			.description("설명")
@@ -68,44 +66,31 @@ class CourseServiceTest {
 			.build();
 		ReflectionTestUtils.setField(course, "id", 100L);
 
-		// 3. 커리큘럼(Lecture) 생성 및 추가
 		Lecture lecture1 = Lecture.builder().title("1강 OT").duration(600).course(course).build();
 		Lecture lecture2 = Lecture.builder().title("2강 개요").duration(1200).course(course).build();
-
-		// Entity의 lectures 리스트에 수동으로 추가 (테스트 환경이므로)
 		course.getLectures().add(lecture1);
 		course.getLectures().add(lecture2);
 
-		// 4. Mocking: Repository 호출 시 위에서 만든 course 반환
-		given(courseRepository.findByIdWithDetail(100L)).willReturn(Optional.of(course));
+		given(courseRepository.findById(100L)).willReturn(Optional.of(course));
 
 		// when
 		CourseDetailRes result = courseService.getCourseDetail(100L);
 
 		// then
-		// 1. 강의 기본 정보 검증
 		assertThat(result.getCourseId()).isEqualTo(100L);
-		assertThat(result.getTitle()).isEqualTo("스프링 완전 정복");
-
-		// 2. 지식공유자(Lecturer) 정보 검증 (Tutor -> Lecturer 용어 변경 반영 확인)
-		assertThat(result.getLecturer().getLecturerId()).isEqualTo(1L);
 		assertThat(result.getLecturer().getName()).isEqualTo("김스프링");
-
-		// 3. 커리큘럼(Lecture) 정보 검증
 		assertThat(result.getCurriculum()).hasSize(2);
-		assertThat(result.getCurriculum().get(0).getTitle()).isEqualTo("1강 OT");
-		assertThat(result.getCurriculum().get(0).getDuration()).isEqualTo(600);
 
-		// 4. 호출 여부 검증
-		verify(courseRepository).findByIdWithDetail(100L);
+		verify(courseRepository).findById(100L);
 	}
 
 	@Test
 	@DisplayName("실패: 존재하지 않는 강의 ID 조회 시 COURSE_NOT_FOUND 예외가 발생한다.")
 	void getCourseDetail_Fail_NotFound() {
+
 		// given
 		Long invalidCourseId = 999L;
-		given(courseRepository.findByIdWithDetail(invalidCourseId)).willReturn(Optional.empty());
+		given(courseRepository.findById(invalidCourseId)).willReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(() -> courseService.getCourseDetail(invalidCourseId))
@@ -117,52 +102,28 @@ class CourseServiceTest {
 	@Test
 	@DisplayName("성공: 강의 목록을 페이징하여 조회하면, CourseListRes Page가 반환된다.")
 	void getCourseList_Success() {
-		// given
-		// 1. 페이징 요청 객체 생성 (0페이지, 10개씩)
-		Pageable pageable = PageRequest.of(0, 10);
 
-		// 2. 강사 및 강의 데이터 생성
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
 		User lecturer = User.createForSignup("이자바", "java@test.com", "hash", "01011112222");
 
-		Course course1 = Course.builder()
-			.title("자바의 정석")
-			.description("기초")
-			.category("BACKEND")
-			.price(BigDecimal.valueOf(10000))
-			.lecturer(lecturer)
-			.build();
+		Course course1 = Course.builder().title("자바").price(BigDecimal.valueOf(10000)).lecturer(lecturer).build();
 		ReflectionTestUtils.setField(course1, "id", 1L);
-
-		Course course2 = Course.builder()
-			.title("JPA 프로그래밍")
-			.description("심화")
-			.category("BACKEND")
-			.price(BigDecimal.valueOf(20000))
-			.lecturer(lecturer)
-			.build();
+		Course course2 = Course.builder().title("JPA").price(BigDecimal.valueOf(20000)).lecturer(lecturer).build();
 		ReflectionTestUtils.setField(course2, "id", 2L);
 
-		// 3. Mock Page 객체 생성 (DB에서 반환될 예상 결과)
 		List<Course> courseList = List.of(course1, course2);
 		Page<Course> mockPage = new PageImpl<>(courseList, pageable, 2);
 
-		// 4. Mocking: Repository 호출 시 mockPage 반환
-		given(courseRepository.findAllWithLecturer(any(Pageable.class))).willReturn(mockPage);
+		given(courseRepository.findAll(any(Pageable.class))).willReturn(mockPage);
 
 		// when
 		Page<CourseListRes> result = courseService.getCourseList(pageable);
 
 		// then
-		// 1. 페이지 크기 및 내용 검증
 		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("이자바");
 
-		// 2. 데이터 매핑 검증 (Entity -> DTO 변환 확인)
-		assertThat(result.getContent().get(0).getTitle()).isEqualTo("자바의 정석");
-		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("이자바"); // 강사 이름 확인
-		assertThat(result.getContent().get(1).getPrice()).isEqualTo(BigDecimal.valueOf(20000));
-
-		// 3. 호출 검증
-		verify(courseRepository).findAllWithLecturer(any(Pageable.class));
+		verify(courseRepository).findAll(any(Pageable.class));
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -1,0 +1,80 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+
+/**
+ * LecturerCourseService(지식공유자 전용) 비즈니스 로직 테스트 클래스입니다.
+ * <p>
+ * 대상 클래스: LecturerCourseService
+ * 주요 기능: 강의 등록, 수정, 삭제
+ * </p>
+ *
+ * @author 기섭
+ * @since 2026. 1. 28.
+ */
+@ExtendWith(MockitoExtension.class)
+class LecturerCourseServiceTest {
+
+	@InjectMocks
+	private LecturerCourseService lecturerCourseService;
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("성공: 강의 등록 정보를 입력하면 저장 후 생성된 강의 ID를 반환한다.")
+	void registerCourse_Success() {
+
+		// given
+		CourseRegisterReq req = new CourseRegisterReq();
+		ReflectionTestUtils.setField(req, "title", "새로운 강의");
+		ReflectionTestUtils.setField(req, "description", "강의 설명입니다.");
+		ReflectionTestUtils.setField(req, "category", "BACKEND");
+		ReflectionTestUtils.setField(req, "price", BigDecimal.valueOf(30000));
+		ReflectionTestUtils.setField(req, "thumbnailUrl", "https://thumb.jpg");
+
+		User lecturer = User.createForSignup("김강사", "tutor@test.com", "hash", "01099998888");
+		ReflectionTestUtils.setField(lecturer, "id", 1L);
+
+		Course savedCourse = Course.builder()
+			.title(req.getTitle())
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(savedCourse, "id", 100L); // DB 저장을 흉내내어 ID 주입
+
+		given(userRepository.findById(1L)).willReturn(Optional.of(lecturer)); // 유저 찾기 성공
+		given(courseRepository.save(any(Course.class))).willReturn(savedCourse); // 저장 성공
+
+		// when
+		CourseRegisterRes result = lecturerCourseService.registerCourse(req);
+
+		// then
+		assertThat(result.getCourseId()).isEqualTo(100L);
+		
+		verify(userRepository).findById(1L);
+		verify(courseRepository).save(any(Course.class));
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #26 

---

## ✨ 작업 내용
로그인 여부와 관계없이 누구나 접근 가능한 **강의 전체 목록 조회(페이징)** 기능을 구현했습니다. 

- [x] 기능 추가
**강의 목록 조회 API 구현 (`GET /api/v1/courses`)**
* **페이징(Pagination):** `Pageable` 인터페이스를 활용하여 다건의 데이터를 효율적으로 조회하도록 구현했습니다. (기본값: 최신순, 10개)
- [x] 리팩토링


---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. 

---

## 💬 리뷰어에게
이전 PR의 코드 리뷰도 반영하였습니다. 