### PR TITLE
[feat]  주문 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/controller/OrderController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/controller/OrderController.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.order.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,11 +9,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -40,5 +44,13 @@ public class OrderController {
 		Long userId = 1L;
 		CreateOrderRes response = orderService.createOrder(userId, request);
 		return ApiResponse.of(SuccessCode.CREATED, response);
+	}
+
+	@GetMapping("/{orderId}")
+	public ApiResponse<GetOrderDetailRes> getOrder(@PathVariable @Positive Long orderId) {
+
+		Long userId = 1L;
+		GetOrderDetailRes response = orderService.getOrder(userId, orderId);
+		return ApiResponse.of(SuccessCode.OK, response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/CreateOrderRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/CreateOrderRes.java
@@ -23,15 +23,10 @@ import lombok.RequiredArgsConstructor;
 @Builder
 public class CreateOrderRes {
 
-	private final List<CreateOrderItemRes> items;
-
+	private final List<OrderItemRes> items;
 	private final Long orderId;
-
 	private final Long userId;
-
 	private final BigDecimal totalAmount;
-
 	private final BigDecimal usePoint;
-
 	private final LocalDateTime createdAt;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/GetOrderDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/GetOrderDetailRes.java
@@ -1,0 +1,33 @@
+package com.github.sleeplessspecialist.peaktime.domain.order.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 주문 상세 조회 api 호출시 클라이언트에게 반환되는 응답 DTO
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.27
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class GetOrderDetailRes {
+
+	private final List<OrderItemRes> items;
+	private final Long orderId;
+	private final Long userId;
+	private final BigDecimal totalAmount;
+	private final BigDecimal usePoint;
+	private final OrderStatus orderStatus;
+	private final LocalDateTime createTime;
+	private final LocalDateTime updateTime;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/OrderItemRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/OrderItemRes.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @Builder
-public class CreateOrderItemRes {
+public class OrderItemRes {
 
 	private final Long orderItemId;
 	private final Long courseId;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -23,7 +23,8 @@ public enum OrderErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("O001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
 	COURSE_NOT_FOUND("O002", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND),
-	INSUFFICIENT_POINT("0002" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST);
+	ORDER_NOT_FOUND("0003", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
+	INSUFFICIENT_POINT("0004" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST);
 	private final String code;
 	private final String message;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -21,10 +21,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
 
-	USER_NOT_FOUND("O001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	COURSE_NOT_FOUND("O002", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND),
-	ORDER_NOT_FOUND("0003", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
-	INSUFFICIENT_POINT("0004" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST);
+	USER_NOT_FOUND("OD-001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+	COURSE_NOT_FOUND("OD-002", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND),
+	ORDER_NOT_FOUND("OD-003", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
+	UNAUTHORIZED_ACCESS("OD-004", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST);
+
 	private final String code;
 	private final String message;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/repository/OrderItemRepository.java
@@ -1,6 +1,10 @@
 package com.github.sleeplessspecialist.peaktime.domain.order.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
 
@@ -15,4 +19,13 @@ import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
  * @since
  */
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+	@Query("""
+    select oi
+    from OrderItem oi
+    join fetch oi.course c
+    where oi.order.id = :orderId
+""")
+	List<OrderItem> findAllByOrderId(@Param("orderId") Long orderId);
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
@@ -10,9 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemReq;
-import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.OrderItemRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
@@ -45,6 +46,14 @@ public class OrderService {
 	private final OrderRepository orderRepository;
 	private final OrderItemRepository orderItemRepository;
 
+	/**
+	 * 주문 생성
+	 * 1. userId DB 존재 여부 확인
+	 * 2. 사용 포인트 유효성 검증
+	 * 3. 주문 및 장바구니 생성
+	 * 4. 총 주문 금액 계산 및 반영
+	 * 5. 응답 dto 생성 후 리턴
+	 */
 	@Transactional
 	public CreateOrderRes createOrder(Long userId, CreateOrderReq request) {
 
@@ -54,11 +63,7 @@ public class OrderService {
 		BigDecimal usePoint = request.getUsePoint();
 		BigDecimal userPoint = BigDecimal.valueOf(user.getPoint());
 
-		if (userPoint.compareTo(usePoint) < 0) {
-			log.warn("보유 포인트 부족 : user_id={}, 보유 포인트={}, 사용 포인트={}",
-				userId, userPoint, usePoint);
-			throw new CustomException(OrderErrorCode.INSUFFICIENT_POINT);
-		}
+		validateSufficientPoint(userId, userPoint, usePoint);
 
 		Order order = Order.builder()
 			.user(user)
@@ -68,7 +73,7 @@ public class OrderService {
 
 		orderRepository.save(order);
 
-		List<CreateOrderItemRes> orderItems = new ArrayList<>();
+		List<OrderItemRes> orderItems = new ArrayList<>();
 
 		for (CreateOrderItemReq orderItem : request.getOrderItems()) {
 
@@ -83,7 +88,7 @@ public class OrderService {
 				.build();
 			orderItemRepository.save(saved);
 
-			orderItems.add(CreateOrderItemRes.builder()
+			orderItems.add(OrderItemRes.builder()
 				.orderItemId(saved.getId())
 				.courseId(course.getId())
 				.price(course.getPrice())
@@ -103,18 +108,69 @@ public class OrderService {
 	}
 
 	/**
-	 * User 가 DB 에 존재 하는지 검증 + 없다면 throw
+	 * 주문 상세 조회
+	 * 1. userId DB 존재 여부 확인
+	 * 2. orderId DB 존재 여부 확인
+	 * 3. user 의 권한 검증
+	 * 4. 응답 dto 생성후 리턴
 	 */
+	@Transactional(readOnly = true)
+	public GetOrderDetailRes getOrder(Long userId, Long orderId) {
+
+		User user = getUser(userId);
+		Order order = getOrder(orderId);
+
+		validateAccess(user, order);
+
+		List<OrderItemRes> items = new ArrayList<>();
+
+		for (OrderItem item : orderItemRepository.findAllByOrderId(orderId)) {
+			items.add(OrderItemRes.builder()
+				.orderItemId(item.getId())
+				.courseId(item.getCourse().getId())
+				.price(item.getPrice())
+				.build());
+		}
+
+		return GetOrderDetailRes.builder()
+			.items(items)
+			.orderId(order.getId())
+			.userId(order.getUser().getId())
+			.totalAmount(order.getTotalAmount())
+			.usePoint(order.getUsePoint())
+			.orderStatus(order.getStatus())
+			.createTime(order.getCreatedAt())
+			.updateTime(order.getUpdatedAt())
+			.build();
+	}
+
 	private User getUser(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(OrderErrorCode.USER_NOT_FOUND));
 	}
 
-	/**
-	 * Course 가 DB 에 존재 하는지 검증 + 없다면 throw
-	 */
 	private Course getCourse(Long courseId) {
 		return courseRepository.findById(courseId)
 			.orElseThrow(() -> new CustomException(OrderErrorCode.COURSE_NOT_FOUND));
+	}
+
+	private Order getOrder(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
+	}
+
+	private void validateAccess(User user, Order order) {
+		if (!user.getId().equals(order.getUser().getId())) {
+			log.warn("주문 조회 권한이 없습니다. userId = {}", user.getId());
+			throw new CustomException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
+
+	private void validateSufficientPoint(Long userId, BigDecimal userPoint, BigDecimal usePoint) {
+		if (userPoint.compareTo(usePoint) < 0) {
+			log.warn("보유 포인트 부족 : user_id={}, 사용자 보유 포인트={}, 사용 포인트={}",
+				userId, userPoint, usePoint);
+			throw new CustomException(OrderErrorCode.INSUFFICIENT_POINT);
+		}
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
@@ -1,0 +1,164 @@
+package com.github.sleeplessspecialist.peaktime.domain.order;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemReq;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
+import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderItemRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderService;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+/**
+ * OrderService 단위 테스트
+ * <p>
+ * 주문(Order) 도메인의 내부로직 단위 테스트
+ * </p>
+ *
+ * @author 우재
+ * @since 2026. 1. 27.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+	@InjectMocks
+	private OrderService orderService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Mock
+	private OrderRepository orderRepository;
+
+	@Mock
+	private OrderItemRepository orderItemRepository;
+
+	@Test
+	@DisplayName("createOrder: totalAmount 합산, order/items 저장, 응답 필드 확인")
+	void createOrder_success() {
+		// given
+		Long userId = 1L;
+		User user = User.createForSignup("우재", "test@test.com", "password1234", "010-0000-0000");
+		user.addPoint(5000L);
+
+		Course course1 = Course.builder()
+			.title("course-1")
+			.description("desc-1")
+			.category("cat-1")
+			.price(new BigDecimal("10000"))
+			.thumbnailUrl("thumb-1")
+			.lecturer(user)
+			.build();
+		ReflectionTestUtils.setField(course1, "id", 11L);
+
+		Course course2 = Course.builder()
+			.title("course-2")
+			.description("desc-2")
+			.category("cat-2")
+			.price(new BigDecimal("15000"))
+			.thumbnailUrl("thumb-2")
+			.lecturer(user)
+			.build();
+		ReflectionTestUtils.setField(course2, "id", 12L);
+
+		CreateOrderReq request = new CreateOrderReq(
+			List.of(new CreateOrderItemReq(11L), new CreateOrderItemReq(12L)),
+			new BigDecimal("1000")
+		);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+		when(courseRepository.findById(11L)).thenReturn(java.util.Optional.of(course1));
+		when(courseRepository.findById(12L)).thenReturn(java.util.Optional.of(course2));
+
+		when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+			Order order = invocation.getArgument(0);
+			ReflectionTestUtils.setField(order, "id", 100L);
+			return order;
+		});
+
+		when(orderItemRepository.save(any(OrderItem.class))).thenAnswer(invocation -> {
+			OrderItem item = invocation.getArgument(0);
+			if (item.getId() == null) {
+				Long id = item.getCourse().getId() + 1000L;
+				ReflectionTestUtils.setField(item, "id", id);
+			}
+			return item;
+		});
+
+		// when
+		CreateOrderRes response = orderService.createOrder(userId, request);
+
+		// then
+		ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+		verify(orderRepository).save(orderCaptor.capture());
+		Order savedOrder = orderCaptor.getValue();
+		assertThat(savedOrder.getTotalAmount()).isEqualByComparingTo("25000");
+		assertThat(savedOrder.getUsePoint()).isEqualByComparingTo("1000");
+
+		verify(orderItemRepository, times(2)).save(any(OrderItem.class));
+
+		assertThat(response.getOrderId()).isEqualTo(100L);
+		assertThat(response.getUserId()).isEqualTo(userId);
+		assertThat(response.getTotalAmount()).isEqualByComparingTo("25000");
+		assertThat(response.getUsePoint()).isEqualByComparingTo("1000");
+		assertThat(response.getItems()).hasSize(2);
+
+		assertThat(response.getItems().get(0).getCourseId()).isEqualTo(11L);
+		assertThat(response.getItems().get(0).getOrderItemId()).isEqualTo(1011L);
+		assertThat(response.getItems().get(0).getPrice()).isEqualByComparingTo("10000");
+
+		assertThat(response.getItems().get(1).getCourseId()).isEqualTo(12L);
+		assertThat(response.getItems().get(1).getOrderItemId()).isEqualTo(1012L);
+		assertThat(response.getItems().get(1).getPrice()).isEqualByComparingTo("15000");
+	}
+
+	@Test
+	@DisplayName("createOrder: 보유 포인트 부족이면 예외")
+	void createOrder_insufficientPoint() {
+		// given
+		Long userId = 1L;
+		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
+
+		CreateOrderReq request = new CreateOrderReq(
+			List.of(new CreateOrderItemReq(11L)),
+			new BigDecimal("1000")
+		);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+
+		// when / then
+		assertThatThrownBy(() -> orderService.createOrder(userId, request))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+				.isEqualTo(OrderErrorCode.INSUFFICIENT_POINT));
+
+		verify(orderRepository, never()).save(any(Order.class));
+		verify(orderItemRepository, never()).save(any(OrderItem.class));
+	}
+
+}

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
@@ -21,8 +21,10 @@ import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRe
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderItemRepository;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
@@ -139,7 +141,7 @@ class OrderServiceTest {
 
 	@Test
 	@DisplayName("createOrder: 보유 포인트 부족이면 예외")
-	void createOrder_insufficientPoint() {
+void createOrder_insufficientPoint() {
 		// given
 		Long userId = 1L;
 		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
@@ -161,4 +163,111 @@ class OrderServiceTest {
 		verify(orderItemRepository, never()).save(any(OrderItem.class));
 	}
 
+	@Test
+	@DisplayName("getOrder: 주문 상세 조회 성공")
+	void getOrder_success() {
+		// given
+		Long userId = 1L;
+		Long orderId = 100L;
+
+		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		Course course1 = Course.builder()
+			.title("course-1")
+			.description("desc-1")
+			.category("cat-1")
+			.price(new BigDecimal("10000"))
+			.thumbnailUrl("thumb-1")
+			.lecturer(user)
+			.build();
+		ReflectionTestUtils.setField(course1, "id", 11L);
+
+		Course course2 = Course.builder()
+			.title("course-2")
+			.description("desc-2")
+			.category("cat-2")
+			.price(new BigDecimal("15000"))
+			.thumbnailUrl("thumb-2")
+			.lecturer(user)
+			.build();
+		ReflectionTestUtils.setField(course2, "id", 12L);
+
+		Order order = Order.builder()
+			.user(user)
+			.totalAmount(new BigDecimal("25000"))
+			.usePoint(new BigDecimal("1000"))
+			.build();
+		ReflectionTestUtils.setField(order, "id", orderId);
+		ReflectionTestUtils.setField(order, "status", OrderStatus.PENDING_PAYMENT);
+		ReflectionTestUtils.setField(order, "createdAt", java.time.LocalDateTime.of(2026, 1, 27, 10, 0));
+		ReflectionTestUtils.setField(order, "updatedAt", java.time.LocalDateTime.of(2026, 1, 27, 10, 5));
+
+		OrderItem item1 = OrderItem.builder()
+			.order(order)
+			.course(course1)
+			.price(course1.getPrice())
+			.build();
+		ReflectionTestUtils.setField(item1, "id", 1011L);
+
+		OrderItem item2 = OrderItem.builder()
+			.order(order)
+			.course(course2)
+			.price(course2.getPrice())
+			.build();
+		ReflectionTestUtils.setField(item2, "id", 1012L);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+		when(orderRepository.findById(orderId)).thenReturn(java.util.Optional.of(order));
+		when(orderItemRepository.findAllByOrderId(orderId)).thenReturn(List.of(item1, item2));
+
+		// when
+		GetOrderDetailRes response = orderService.getOrder(userId, orderId);
+
+		// then
+		assertThat(response.getOrderId()).isEqualTo(orderId);
+		assertThat(response.getUserId()).isEqualTo(userId);
+		assertThat(response.getTotalAmount()).isEqualByComparingTo("25000");
+		assertThat(response.getUsePoint()).isEqualByComparingTo("1000");
+		assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PENDING_PAYMENT);
+		assertThat(response.getCreateTime()).isEqualTo(java.time.LocalDateTime.of(2026, 1, 27, 10, 0));
+		assertThat(response.getUpdateTime()).isEqualTo(java.time.LocalDateTime.of(2026, 1, 27, 10, 5));
+		assertThat(response.getItems()).hasSize(2);
+		assertThat(response.getItems().get(0).getOrderItemId()).isEqualTo(1011L);
+		assertThat(response.getItems().get(0).getCourseId()).isEqualTo(11L);
+		assertThat(response.getItems().get(0).getPrice()).isEqualByComparingTo("10000");
+		assertThat(response.getItems().get(1).getOrderItemId()).isEqualTo(1012L);
+		assertThat(response.getItems().get(1).getCourseId()).isEqualTo(12L);
+		assertThat(response.getItems().get(1).getPrice()).isEqualByComparingTo("15000");
+	}
+
+	@Test
+	@DisplayName("getOrder: 다른 사용자 주문 조회 시 예외")
+	void getOrder_unauthorizedAccess() {
+		// given
+		Long userId = 1L;
+		Long orderId = 100L;
+
+		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		User otherUser = User.createForSignup("other", "other@test.com", "encoded", "010-0000-0001");
+		ReflectionTestUtils.setField(otherUser, "id", 2L);
+
+		Order order = Order.builder()
+			.user(otherUser)
+			.totalAmount(new BigDecimal("25000"))
+			.usePoint(new BigDecimal("1000"))
+			.build();
+		ReflectionTestUtils.setField(order, "id", orderId);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+		when(orderRepository.findById(orderId)).thenReturn(java.util.Optional.of(order));
+
+		// when / then
+		assertThatThrownBy(() -> orderService.getOrder(userId, orderId))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+				.isEqualTo(OrderErrorCode.UNAUTHORIZED_ACCESS));
+	}
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #68 

---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

- [x] 기능 추가
- 주문 상세 조회 API 추가 (정상 조회 시 200 OK) + 경로 변수 Bean Validation 적용
- **주문 상세 로직 구현 및 주문 생성 로직 리팩토링**
   - N+1 방지 목적의 fetch join 기반 조회 쿼리/메서드 추가
   - 포인트 검증 로직을 메서드로 분리, 주석 보강
- 테스트/안정성 보강
  - 주문 생성 단위 테스트 추가
- [x] 리팩토링/버그 수정
DTO 네이밍 정리: CreateOrderItemRes -> OrderItemRes
---

## 📸 스크린샷 (선택)
<img width="629" height="64" alt="image" src="https://github.com/user-attachments/assets/c682fa1b-7e80-4687-8f69-d34209a155e5" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
테스트 커밋 푸쉬 중에 데탑 노트북 번갈아 가면서 쓰다가 불필요한 충돌이 발생했습니다.
반성 합니다.