### PR TITLE
[feat] 주문 전체 조회 API 구현

### DIFF
--- a/http/order.http
+++ b/http/order.http
@@ -1,14 +1,20 @@
-# 환경 변수
+### 환경 변수
 @host = http://localhost:8080
 @contentType = application/json
-
-# 주문 생성
+@orderId =2
+### 주문 생성
 POST {{host}}/api/v1/orders
 Content-Type: {{contentType}}
 
 {
   "orderItems": [
-    { "courseId": 1 }
+    { "courseId": 1 },
+    {"courseId": 2}
   ],
   "usePoint": 1000
 }
+### 주문 상세조회
+GET {{host}}/api/v1/orders/{{orderId}}
+
+### 주문 전체조회
+GET {{host}}/api/v1/orders

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/controller/OrderController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/controller/OrderController.java
@@ -1,5 +1,8 @@
 package com.github.sleeplessspecialist.peaktime.domain.order.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderListRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
@@ -47,10 +51,23 @@ public class OrderController {
 	}
 
 	@GetMapping("/{orderId}")
-	public ApiResponse<GetOrderDetailRes> getOrder(@PathVariable @Positive Long orderId) {
+	public ApiResponse<GetOrderDetailRes> getOrderDetail(@PathVariable @Positive Long orderId) {
 
 		Long userId = 1L;
-		GetOrderDetailRes response = orderService.getOrder(userId, orderId);
+		GetOrderDetailRes response = orderService.getOrderDetail(userId, orderId);
 		return ApiResponse.of(SuccessCode.OK, response);
 	}
+
+	@GetMapping
+	public ApiResponse<GetOrderListRes> getAllOrder(
+		@PageableDefault(
+			size = 10,
+			sort = "createdAt",
+			direction = Sort.Direction.DESC
+		) Pageable pageable
+	) {
+		Long userId = 1L;
+		return ApiResponse.of(SuccessCode.OK, orderService.getAllOrder(userId, pageable));
+	}
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/GetOrderListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/GetOrderListRes.java
@@ -1,0 +1,31 @@
+package com.github.sleeplessspecialist.peaktime.domain.order.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 주문 목록 조회 API의 응답 DTO
+ * <p>
+ * 클라이언트에게 페이징 처리된 주문 목록과 함께 현재 페이지 정보, 페이지 크기,
+ * 전체 주문 개수, 전체 페이지 수, 다음 페이지 존재 여부를 전달합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class GetOrderListRes {
+
+	private final List<OrderListItemRes> orders;
+	private final int page;
+	private final int size;
+	private final long totalElements;
+	private final int totalPages;
+	private final boolean hasNext;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/OrderListItemRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/dto/OrderListItemRes.java
@@ -1,0 +1,46 @@
+package com.github.sleeplessspecialist.peaktime.domain.order.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 주문 목록 조회 시 각 주문을 구성하는 단일 항목(Response Item) DTO
+ * <p>
+ * 주문 ID, 주문자 ID, 총 결제 금액, 사용 포인트, 주문 상태, 주문 생성 시각 정보를 포함하며,
+ * 주문 목록 화면에서 각 주문의 요약 정보를 표시하는 용도로 사용됩니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class OrderListItemRes {
+
+	private final Long orderId;
+	private final Long userId;
+	private final BigDecimal totalAmount;
+	private final BigDecimal userPoint;
+	private final OrderStatus orderStatus;
+	private final LocalDateTime createAt;
+
+	public static OrderListItemRes from(Order order) {
+		return OrderListItemRes.builder()
+			.orderId(order.getId())
+			.userId(order.getUser().getId())
+			.totalAmount(order.getTotalAmount())
+			.userPoint(order.getUsePoint())
+			.orderStatus(order.getStatus())
+			.createAt(order	.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -25,7 +25,8 @@ public enum OrderErrorCode implements ErrorCode {
 	COURSE_NOT_FOUND("OD-002", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND),
 	ORDER_NOT_FOUND("OD-003", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
 	UNAUTHORIZED_ACCESS("OD-004", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
-	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST);
+	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST),
+	BAD_PAGING_CONDITION("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/repository/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.github.sleeplessspecialist.peaktime.domain.order.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 
 /**
  *  주문(Order) 엔티티에 대한 영속성 처리를 담당하는 Repository 인터페이스.
@@ -15,4 +18,5 @@ import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
  * @since
  */
 public interface OrderRepository extends JpaRepository<Order, Long> {
+	Page<Order> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
@@ -4,16 +4,21 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.sleeplessspecialist.peaktime.domain.chat.exception.ChatErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderListRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.OrderItemRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.OrderListItemRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
@@ -115,7 +120,7 @@ public class OrderService {
 	 * 4. 응답 dto 생성후 리턴
 	 */
 	@Transactional(readOnly = true)
-	public GetOrderDetailRes getOrder(Long userId, Long orderId) {
+	public GetOrderDetailRes getOrderDetail(Long userId, Long orderId) {
 
 		User user = getUser(userId);
 		Order order = getOrder(orderId);
@@ -144,6 +149,30 @@ public class OrderService {
 			.build();
 	}
 
+	@Transactional(readOnly = true)
+	public GetOrderListRes getAllOrder(Long userId, Pageable pageable) {
+
+		User user = getUser(userId);
+
+		validatePageable(pageable);
+
+		Page<Order> orderPage = orderRepository.findByUser(user, pageable);
+
+		List<OrderListItemRes> orders = orderPage.getContent().stream()
+			.map(OrderListItemRes::from)
+			.toList();
+
+		return GetOrderListRes.builder()
+			.orders(orders)
+			.page(orderPage.getNumber())
+			.size(orderPage.getSize())
+			.totalElements(orderPage.getTotalElements())
+			.totalPages(orderPage.getTotalPages())
+			.hasNext(orderPage.hasNext())
+			.build();
+	}
+
+
 	private User getUser(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(OrderErrorCode.USER_NOT_FOUND));
@@ -171,6 +200,20 @@ public class OrderService {
 			log.warn("보유 포인트 부족 : user_id={}, 사용자 보유 포인트={}, 사용 포인트={}",
 				userId, userPoint, usePoint);
 			throw new CustomException(OrderErrorCode.INSUFFICIENT_POINT);
+		}
+	}
+
+	private void validatePageable(Pageable pageable) {
+
+		int page = pageable.getPageNumber();
+		int size = pageable.getPageSize();
+
+		if (page < 0) {
+			throw new CustomException(OrderErrorCode.BAD_PAGING_CONDITION);
+		}
+
+		if (size < 1 || size > 50) {
+			throw new CustomException(OrderErrorCode.BAD_PAGING_CONDITION);
 		}
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/order/OrderServiceTest.java
@@ -14,6 +14,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
@@ -22,6 +25,7 @@ import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemR
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderReq;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.order.dto.GetOrderListRes;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
@@ -222,7 +226,7 @@ void createOrder_insufficientPoint() {
 		when(orderItemRepository.findAllByOrderId(orderId)).thenReturn(List.of(item1, item2));
 
 		// when
-		GetOrderDetailRes response = orderService.getOrder(userId, orderId);
+		GetOrderDetailRes response = orderService.getOrderDetail(userId, orderId);
 
 		// then
 		assertThat(response.getOrderId()).isEqualTo(orderId);
@@ -265,9 +269,88 @@ void createOrder_insufficientPoint() {
 		when(orderRepository.findById(orderId)).thenReturn(java.util.Optional.of(order));
 
 		// when / then
-		assertThatThrownBy(() -> orderService.getOrder(userId, orderId))
+		assertThatThrownBy(() -> orderService.getOrderDetail(userId, orderId))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
 				.isEqualTo(OrderErrorCode.UNAUTHORIZED_ACCESS));
+	}
+
+	@Test
+	@DisplayName("getAllOrder: 주문 전체 조회 성공")
+	void getAllOrder_success() {
+		// given
+		Long userId = 1L;
+
+		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		Order order1 = Order.builder()
+			.user(user)
+			.totalAmount(new BigDecimal("20000"))
+			.usePoint(new BigDecimal("1000"))
+			.build();
+		ReflectionTestUtils.setField(order1, "id", 100L);
+		ReflectionTestUtils.setField(order1, "status", OrderStatus.PENDING_PAYMENT);
+		ReflectionTestUtils.setField(order1, "createdAt", java.time.LocalDateTime.of(2026, 1, 27, 9, 0));
+
+		Order order2 = Order.builder()
+			.user(user)
+			.totalAmount(new BigDecimal("15000"))
+			.usePoint(new BigDecimal("500"))
+			.build();
+		ReflectionTestUtils.setField(order2, "id", 101L);
+		ReflectionTestUtils.setField(order2, "status", OrderStatus.PENDING_PAYMENT);
+		ReflectionTestUtils.setField(order2, "createdAt", java.time.LocalDateTime.of(2026, 1, 27, 10, 0));
+
+		PageRequest pageable = PageRequest.of(0, 2);
+		Page<Order> orderPage = new PageImpl<>(List.of(order1, order2), pageable, 4);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+		when(orderRepository.findByUser(user, pageable)).thenReturn(orderPage);
+
+		// when
+		GetOrderListRes response = orderService.getAllOrder(userId, pageable);
+
+		// then
+		assertThat(response.getOrders()).hasSize(2);
+
+		assertThat(response.getOrders().get(0).getOrderId()).isEqualTo(100L);
+		assertThat(response.getOrders().get(0).getUserId()).isEqualTo(userId);
+		assertThat(response.getOrders().get(0).getTotalAmount()).isEqualByComparingTo("20000");
+		assertThat(response.getOrders().get(0).getUserPoint()).isEqualByComparingTo("1000");
+		assertThat(response.getOrders().get(0).getOrderStatus()).isEqualTo(OrderStatus.PENDING_PAYMENT);
+		assertThat(response.getOrders().get(0).getCreateAt()).isEqualTo(java.time.LocalDateTime.of(2026, 1, 27, 9, 0));
+
+		assertThat(response.getOrders().get(1).getOrderId()).isEqualTo(101L);
+		assertThat(response.getOrders().get(1).getUserId()).isEqualTo(userId);
+		assertThat(response.getOrders().get(1).getTotalAmount()).isEqualByComparingTo("15000");
+		assertThat(response.getOrders().get(1).getUserPoint()).isEqualByComparingTo("500");
+		assertThat(response.getOrders().get(1).getOrderStatus()).isEqualTo(OrderStatus.PENDING_PAYMENT);
+		assertThat(response.getOrders().get(1).getCreateAt()).isEqualTo(java.time.LocalDateTime.of(2026, 1, 27, 10, 0));
+
+		assertThat(response.getPage()).isEqualTo(0);
+		assertThat(response.getSize()).isEqualTo(2);
+		assertThat(response.getTotalElements()).isEqualTo(4);
+		assertThat(response.getTotalPages()).isEqualTo(2);
+		assertThat(response.isHasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("getAllOrder: 페이지 조건 불일치 예외")
+	void getAllOrder_invalidPageSize() {
+		// given
+		Long userId = 1L;
+		User user = User.createForSignup("tester", "test@test.com", "encoded", "010-0000-0000");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		PageRequest pageable = PageRequest.of(0, 51);
+
+		when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+
+		// when / then
+		assertThatThrownBy(() -> orderService.getAllOrder(userId, pageable))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+				.isEqualTo(OrderErrorCode.BAD_PAGING_CONDITION));
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #66 

---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

- [x] 기능 추가
  - **주문 전체 조회 API 구현**
    - 사용자 기준 주문 목록을 Page로 조회하도록 구현
    - 요청 파라미터 `page/size` 기반 페이지네이션 적용
  - **페이지네이션 입력값 방어 로직 추가**
    - `page < 0`, `size <= 0` 등의 비정상 요청에 대해 예외 처리
  - **응답 DTO 구성**
    - 주문 리스트 + `page/size/totalElements/totalPages/hasNext` 메타 정보 포함
  - **네이밍 리팩토링**
    - 주문 단건 조회 계열 메서드 혼동 방지를 위해 `getOrder -> getOrderDetail`로 명확화

- [x] 테스트 추가/수정
  - **주문 전체 조회 API 테스트 추가**
    - 응답 리스트 및 페이지 메타 데이터가 기대값대로 내려오는지 검증
---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

<img width="587" height="208" alt="image" src="https://github.com/user-attachments/assets/17c86a7b-aa06-4e37-969f-3439f2252e90" />
<img width="849" height="907" alt="image" src="https://github.com/user-attachments/assets/52ab901b-cf69-47cb-86b5-b028c4e7929f" />


## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
앞전 인증인가 미적용 코드가 앞전에 많아서, refactor 브랜치를 따서 한꺼번에 pr 올리려고 합니다.
스크럼간 나왔던 errorCode 관련 내용도  pr 로  올리겠습니다.