### PR TITLE
[feat] 사용자 목록 조회(관리자) API 구현

### DIFF
--- a/http/admin.http
+++ b/http/admin.http
@@ -1,0 +1,40 @@
+@host = http://localhost:8080
+
+### [AUTH] 회원가입 (관리자 계정 후보)
+POST {{host}}/api/v1/auth/signup
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "admin@test.com",
+  "password": "Admin1234!",
+  "phoneNumber": "010-1234-1234",
+  "name": "관리자"
+}
+
+
+
+### [AUTH] 관리자 로그인 (토큰 저장)
+POST {{host}}/api/v1/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "admin@test.com",
+  "password": "Admin1234!"
+}
+
+> {%
+    // 로그인 응답이 ApiResponse 형태라서 accessToken은 data 안에 있습니다.
+    client.global.set("ADMIN_ACCESS_TOKEN", response.body.data.accessToken);
+%}
+
+### [ADMIN] 사용자 목록 기본 조회 (page=0,size=20)
+GET {{host}}/api/v1/admin/users?page=0&size=20
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Accept: application/json
+
+### [ADMIN] size 검증 확인 (size=0 -> 400 기대)
+GET {{host}}/api/v1/admin/users?page=0&size=0
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Accept: application/json

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/admin/AdminUserController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/admin/AdminUserController.java
@@ -1,0 +1,61 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.controller.admin;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserListRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.service.admin.AdminUserService;
+import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
+import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자 사용자(User) 관리 API 컨트롤러입니다.
+ * <p>
+ * 관리자 권한(ROLE_ADMIN)을 가진 사용자만 접근할 수 있으며,
+ * 사용자 목록 조회 등 관리자 전용 기능의 진입점 역할을 수행합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+	private final AdminUserService adminUserService;
+
+	/**
+	 * 사용자 목록을 Page 기반으로 조회합니다. (관리자 권한)
+	 *
+	 * <p>
+	 * {@code page}/{@code size} 기반 페이징을 제공하며, 이메일 또는 이름 키워드 검색({@code q}),
+	 * 사용자 상태({@code status}) 및 역할({@code role}) 필터링을 지원합니다.
+	 * </p>
+	 *
+	 * @param page 조회 페이지 수
+	 * @param size 조회 크기
+	 * @return 조회 성공 응답
+	 */
+	@GetMapping("/users")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ApiResponse<AdminUserListRes> getUsers(
+
+		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+	) {
+		return ApiResponse.of(
+			SuccessCode.OK,
+			adminUserService.getUsers(page, size)
+		);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUserListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUserListRes.java
@@ -1,0 +1,28 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response;
+
+import java.util.List;
+
+/**
+ * 관리자 사용자(User) 목록 조회 응답 레코드 클래스입니다.
+ * <p>
+ * 관리자 사용자 목록 조회 API의 응답 데이터로,
+ * Page 기반 페이징 정보와 사용자 요약 목록을 함께 제공합니다.
+ * </p>
+ *
+ * @param content        사용자 요약 목록 데이터
+ * @param page           현재 페이지 번호(0부터 시작)
+ * @param size           페이지 크기
+ * @param totalElements  전체 사용자 수
+ * @param totalPages     전체 페이지 수
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+public record AdminUserListRes(
+	List<AdminUserSummary> content,
+	int page,
+	int size,
+	long totalElements,
+	int totalPages
+) {}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUserSummary.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUserSummary.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response;
+
+/**
+ * 관리자 사용자(User) 목록 조회 시 사용되는 사용자 요약 응답 레코드입니다.
+ *
+ * <p>
+ * 관리자 사용자 목록 조회 API 응답의 {@code content[]} 요소로 사용되며,
+ * 관리자 화면의 사용자 목록 테이블에 노출되는 최소한의 사용자 정보를 표현합니다.
+ * </p>
+ * <p>
+ * Endpoint: {@code GET /api/v1/admin/users}
+ * </p>
+ *
+ * @param memberId  사용자 ID
+ * @param email     사용자 이메일
+ * @param name      사용자 이름
+ * @param role      사용자 역할(STUDENT | LECTURER | ADMIN)
+ * @param status    사용자 상태(ACTIVE | SUSPENDED | DELETED)
+ * @param createdAt 가입 일시(ISO-8601 문자열)
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+public record AdminUserSummary(
+	Long memberId,
+	String email,
+	String name,
+	String role,
+	String status,
+	String createdAt
+) {}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
@@ -1,0 +1,102 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.service.admin;
+
+import java.time.format.DateTimeFormatter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserListRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserSummary;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관리자 사용자(User) 관리 유스케이스를 처리하는 서비스입니다.
+ *
+ * <p>
+ * 관리자 전용 사용자 목록 조회, 사용자 상태 변경 등 관리 기능을 담당합니다.
+ * 본 서비스는 엔티티를 직접 노출하지 않고, 관리자 전용 DTO로 변환하여 반환합니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AdminUserService {
+
+	private final UserRepository userRepository;
+
+	/**
+	 * 관리자 권한으로 사용자(User) 목록을 페이징 조회합니다.
+	 * <p>
+	 * 기본 조회 구현으로, 주어진 {@code page}/{@code size}에 따라 {@link UserRepository#findAll(Pageable)}을 호출하여
+	 * 사용자 목록을 조회하고 {@link AdminUserSummary} 목록으로 변환한 뒤 {@link AdminUserListRes}로 반환합니다.
+	 * </p>
+	 *
+	 * <p>
+	 * NOTE: 입력값(page/size)의 기본값 적용 및 유효성 검증은 컨트롤러 계층에서 수행합니다.
+	 * (예: page=0, size=20, size 범위 1~100)
+	 * </p>
+	 *
+	 * @param page 조회 페이지 번호(0부터 시작)
+	 * @param size 페이지 크기(1~100)
+	 * @return 사용자 목록 조회 결과(페이징 메타데이터 포함)
+	 */
+	@Transactional(readOnly = true)
+	public AdminUserListRes getUsers(int page, int size) {
+		final Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+		final Page<User> result = userRepository.findAll(pageable);
+
+		final List<AdminUserSummary> content = result.getContent().stream()
+			.map(this::toSummary)
+			.collect(Collectors.toList());
+
+		return new AdminUserListRes(
+			content,
+			result.getNumber(),
+			result.getSize(),
+			result.getTotalElements(),
+			result.getTotalPages()
+		);
+	}
+
+	private AdminUserSummary toSummary(User user) {
+		String createdAt = null;
+		if (user.getCreatedAt() != null) {
+			createdAt = user.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+		}
+
+		String role = null;
+		if (user.getRole() != null) {
+			role = user.getRole().name();
+		}
+
+		String status = null;
+		if (user.getStatus() != null) {
+			status = user.getStatus().name();
+		}
+
+		return new AdminUserSummary(
+			user.getId(),
+			user.getEmail(),
+			user.getName(),
+			role,
+			status,
+			createdAt
+		);
+	}
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/filter/JwtAuthenticationFilter.java
@@ -121,7 +121,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		ErrorResponse errorResponse = ErrorResponse.from(errorCode);
 
 		response.setStatus(errorCode.getHttpStatus().value());
+		response.setCharacterEncoding("UTF-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
 		objectMapper.writeValue(response.getWriter(), errorResponse);
 
 	}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #37 

---

## ✨ 작업 내용
관리자 권한으로 사용자 목록을 기본 페이징(page/size) 기반으로 조회하는 API를 추가했습니다.
또한 HTTP Client 요청을 함께 추가해 로컬에서 빠르게 검증할 수 있도록 했습니다.

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링

- 관리자 사용자 목록 조회 API 추가
  - GET /api/v1/admin/users 
  - page / size 기반 페이징 지원
- 서비스 계층에서 User → AdminUserSummary로 변환 후 AdminUserListRes로 반환
- (버그 수정) JWT 인증 실패 응답의 한글 메시지 인코딩(UTF-8) 명시
- IntelliJ HTTP Client용 admin.http 요청 추가 (회원가입 → 로그인 → 조회)

---

## 📸 스크린샷 (선택)
<img width="471" height="928" alt="image" src="https://github.com/user-attachments/assets/9a6301dc-bce8-4ba4-8e06-dfd7a719ff1a" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. - 단위 테스트는 v1 구현 완료 이후 별도 Issue로 진행

---

## 💬 리뷰어에게
- 현재 PR은 기본 조회(페이징) 까지만 포함합니다.
- q(검색어)/status/role 기반 검색/필터는 Querydsl 적용과 함께 후속 PR에서 추가 예정입니다.
- 기본 회원가입은 `STUDENT` 로 되어있어 별도 DB에서 권한 수정을 해주셔야 정상적으로 테스트 검증이 가능합니다. 