### PR TITLE
[feat] 사용자 상태 변경(관리자) API 구현

### DIFF
--- a/http/admin.http
+++ b/http/admin.http
@@ -1,4 +1,5 @@
 @host = http://localhost:8080
+@TARGET_USER_ID = 2
 
 ### [AUTH] 회원가입 (관리자 계정 후보)
 POST {{host}}/api/v1/auth/signup
@@ -12,7 +13,30 @@ Accept: application/json
   "name": "관리자"
 }
 
+### [AUTH] 회원가입 (테스트 대상 사용자)
+POST {{host}}/api/v1/auth/signup
+Content-Type: application/json
+Accept: application/json
 
+{
+  "email": "user1@test.com",
+  "password": "User1234!",
+  "phoneNumber": "010-9999-9999",
+  "name": "일반유저1"
+}
+
+> {%
+    // 회원가입 응답에서 테스트 대상 사용자 ID를 추출해 TARGET_USER_ID로 저장
+    const data = response.body?.data;
+    const id = data?.id ?? data?.userId ?? data?.memberId;
+    if (id) {
+      client.global.set('TARGET_USER_ID', id);
+      client.log('TARGET_USER_ID set from signup: ' + id);
+    } else {
+      client.log(JSON.stringify(response.body));
+      client.log('회원가입 응답에 id가 없어 TARGET_USER_ID를 자동 세팅하지 못했습니다. (응답에 id/userId/memberId가 있는지 확인)');
+    }
+%}
 
 ### [AUTH] 관리자 로그인 (토큰 저장)
 POST {{host}}/api/v1/auth/login
@@ -26,13 +50,83 @@ Accept: application/json
 
 > {%
     // 로그인 응답이 ApiResponse 형태라서 accessToken은 data 안에 있습니다.
-    client.global.set("ADMIN_ACCESS_TOKEN", response.body.data.accessToken);
+    const token = response.body?.data?.accessToken;
+    if (!token) {
+      client.log(JSON.stringify(response.body));
+      throw new Error('ADMIN_ACCESS_TOKEN을 찾지 못했습니다. 응답의 data.accessToken 구조를 확인하세요.');
+    }
+    client.global.set('ADMIN_ACCESS_TOKEN', token);
+    client.log('ADMIN_ACCESS_TOKEN set');
 %}
 
-### [ADMIN] 사용자 목록 기본 조회 (page=0,size=20)
-GET {{host}}/api/v1/admin/users?page=0&size=20
-Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+### [AUTH] 일반 사용자 로그인 (토큰 저장)
+POST {{host}}/api/v1/auth/login
+Content-Type: application/json
 Accept: application/json
+
+{
+  "email": "user1@test.com",
+  "password": "User1234!"
+}
+
+> {%
+    const token = response.body?.data?.accessToken;
+    if (!token) {
+      client.log(JSON.stringify(response.body));
+      throw new Error('USER_ACCESS_TOKEN을 찾지 못했습니다. 응답의 data.accessToken 구조를 확인하세요.');
+    }
+    client.global.set('USER_ACCESS_TOKEN', token);
+    client.log('USER_ACCESS_TOKEN set');
+%}
+
+# NOTE: 아래 상태 변경(PATCH) 시나리오는 TARGET_USER_ID 세팅이 가능한 경우에만 실행하세요.
+# - 회원가입 응답에 id가 내려오지 않으면 TARGET_USER_ID를 수동으로 설정해야 합니다.
+# - 예: @TARGET_USER_ID = 1
+
+### [ADMIN] 사용자 상태 변경 - ACTIVE → SUSPENDED
+PATCH {{host}}/api/v1/admin/users/{{TARGET_USER_ID}}/status
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "status": "SUSPENDED",
+  "reason": "비정상 활동 감지"
+}
+
+### [ADMIN] 사용자 상태 변경 - 동일 상태 요청 (멱등)
+PATCH {{host}}/api/v1/admin/users/{{TARGET_USER_ID}}/status
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "status": "SUSPENDED",
+  "reason": "이미 정지 상태"
+}
+
+### [ADMIN] 사용자 상태 변경 - ACTIVE/SUSPENDED → DELETED (준비)
+PATCH {{host}}/api/v1/admin/users/{{TARGET_USER_ID}}/status
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "status": "DELETED",
+  "reason": "탈퇴 처리 테스트"
+}
+
+### [ADMIN] 사용자 상태 변경 - DELETED → ACTIVE (실패 기대)
+# 기대: 400 INVALID_STATUS_TRANSITION
+PATCH {{host}}/api/v1/admin/users/{{TARGET_USER_ID}}/status
+Authorization: Bearer {{ADMIN_ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "status": "ACTIVE",
+  "reason": "복구 시도"
+}
 
 ### [ADMIN] size 검증 확인 (size=0 -> 400 기대)
 GET {{host}}/api/v1/admin/users?page=0&size=0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/admin/AdminUserController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/admin/AdminUserController.java
@@ -2,11 +2,17 @@ package com.github.sleeplessspecialist.peaktime.domain.user.controller.admin;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.request.AdminUpdateUserStatusReq;
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUpdateUserStatusRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserListRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.UserStatus;
 import com.github.sleeplessspecialist.peaktime.domain.user.service.admin.AdminUserService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
@@ -56,6 +62,31 @@ public class AdminUserController {
 		return ApiResponse.of(
 			SuccessCode.OK,
 			adminUserService.getUsers(page, size)
+		);
+	}
+
+	/**
+	 * 특정 사용자의 상태(status)를 변경합니다. (관리자 권한)
+	 *
+	 * <p>
+	 * 변경 가능한 상태는 ACTIVE, SUSPENDED, DELETED 입니다.
+	 * DELETED 는 소프트 삭제(탈퇴 처리)로 간주합니다.
+	 * </p>
+	 *
+	 * @param userId 대상 사용자 ID
+	 * @param request 변경 요청 바디(status, reason)
+	 * @return 상태 변경 성공 응답
+	 */
+	@PatchMapping("/users/{userId}/status")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ApiResponse<AdminUpdateUserStatusRes> updateUserStatus(
+		@PathVariable Long userId,
+		@Valid @RequestBody AdminUpdateUserStatusReq request
+	) {
+		UserStatus status = adminUserService.updateUserStatus(userId, request);
+		return ApiResponse.of(
+			SuccessCode.OK,
+			new AdminUpdateUserStatusRes(status)
 		);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/request/AdminUpdateUserStatusReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/request/AdminUpdateUserStatusReq.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.UserStatus;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * AdminUpdateUserStatusReq 클래스입니다.
+ * <p>
+ * 관리자가 특정 사용자의 계정 상태를 변경할 때 사용하는 요청 바디입니다.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminUpdateUserStatusReq {
+
+	@NotNull
+	private UserStatus status;
+
+	@Length(max = 500)
+	private String reason;
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUpdateUserStatusRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/admin/response/AdminUpdateUserStatusRes.java
@@ -1,0 +1,24 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.UserStatus;
+
+/**
+ * 관리자 사용자 상태 변경 응답 DTO
+ *
+ * <p>
+ * 관리자에 의해 사용자 상태가 변경된 후,
+ * 현재 사용자 상태를 클라이언트에 반환하기 위한 응답 객체입니다.
+ * </p>
+ *
+ * @param status 변경된 사용자 상태
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+public record AdminUpdateUserStatusRes(UserStatus status) {
+
+	public static AdminUpdateUserStatusRes from(UserStatus status) {
+		return new AdminUpdateUserStatusRes(status);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/User.java
@@ -120,4 +120,11 @@ public class User extends BaseTimeEntity {
 		this.point = updated;
 	}
 
+	public void changeStatus(UserStatus newStatus) {
+		if (this.status == newStatus) {
+			return;
+		}
+		this.status = newStatus;
+	}
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,34 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *
+ * <p>
+ * TODO: enum의 역할과 각 상수의 의미를 작성하세요.
+ * </p>
+ *
+ * @author 재원
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND("U004", "USER_NOT_FOUND", HttpStatus.NOT_FOUND),
+	INVALID_STATUS_TRANSITION("U400", "INVALID_STATUS_TRANSITION", HttpStatus.BAD_REQUEST);
+
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+
+
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
@@ -95,15 +95,6 @@ public class AdminUserService {
 		UserStatus from = user.getStatus();
 		UserStatus to = request.getStatus();
 
-		if (from == to) {
-			log.info(
-				"[ADMIN] 사용자 상태 변경 없음. userId={}, status={}",
-				userId,
-				from
-			);
-			return from;
-		}
-
 		validateStatusTransition(from, to);
 
 		user.changeStatus(to);
@@ -119,6 +110,11 @@ public class AdminUserService {
 	}
 
 	private void validateStatusTransition(UserStatus from, UserStatus to) {
+
+		// 동일 상태 변경 요청은 멱등 처리(검증/예외 없이 통과)
+		if (from == to) {
+			return;
+		}
 
 		if (from == UserStatus.DELETED) {
 			throw new CustomException(UserErrorCode.INVALID_STATUS_TRANSITION);

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/admin/AdminUserService.java
@@ -12,10 +12,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.request.AdminUpdateUserStatusReq;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserListRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.admin.response.AdminUserSummary;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.UserStatus;
+import com.github.sleeplessspecialist.peaktime.domain.user.exception.UserErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +76,55 @@ public class AdminUserService {
 			result.getTotalPages()
 		);
 	}
+
+	/**
+	 * 관리자 권한으로 특정 사용자의 상태를 변경합니다.
+	 * <p>
+	 * 동일한 상태로의 변경 요청은 멱등하게 처리되며,
+	 * 실제 상태 변경이 발생한 경우에만 도메인 상태를 갱신합니다.
+	 * </p>
+	 *
+	 * @param userId  상태를 변경할 대상 사용자 ID
+	 * @param request 상태 변경 요청 DTO
+	 */
+	@Transactional
+	public UserStatus updateUserStatus(Long userId, AdminUpdateUserStatusReq request) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		UserStatus from = user.getStatus();
+		UserStatus to = request.getStatus();
+
+		if (from == to) {
+			log.info(
+				"[ADMIN] 사용자 상태 변경 없음. userId={}, status={}",
+				userId,
+				from
+			);
+			return from;
+		}
+
+		validateStatusTransition(from, to);
+
+		user.changeStatus(to);
+
+		log.info(
+			"[ADMIN] 사용자 상태 변경 완료. userId={}, from={}, to={}, reason={}",
+			userId,
+			from,
+			to,
+			request.getReason()
+		);
+		return to;
+	}
+
+	private void validateStatusTransition(UserStatus from, UserStatus to) {
+
+		if (from == UserStatus.DELETED) {
+			throw new CustomException(UserErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
 
 	private AdminUserSummary toSummary(User user) {
 		String createdAt = null;


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #42 
---

## ✨ 작업 내용
관리자 전용 사용자 상태 변경 API를 구현하고, 상태 전이 정책 및 HTTP 테스트를 정리했습니다.

- [x] 기능 추가

### 1) 관리자 사용자 상태 변경 API 추가
- PATCH /api/v1/admin/users/{userId}/status
- 요청 DTO / 응답 DTO 구성
- 성공 시 200 OK + 변경된 상태(UserStatus) 반환

### 2) 멱등 처리 및 도메인 메서드 적용
- 동일 상태 요청 시 멱등 처리 (상태 변경 없이 현재 상태 반환)
- User 엔티티에 changeStatus(UserStatus) 도메인 메서드 적용

### 3) 상태 전이 정책 검증(종결 상태)
- DELETED 상태를 종결 상태로 간주하여 상태 변경 차단
- 상태 전이 검증 로직을 서비스 내부 메서드로 분리 (validateStatusTransition)

### 4) 에러코드 추가
- INVALID_STATUS_TRANSITION 에러코드 추가
- 잘못된 상태 전이 요청 시 400 Bad Request 반환

### 5) HTTP 테스트(admin.http) 추가
- 관리자 사용자 상태 변경 PATCH HTTP 테스트 추가
- 회원가입 응답 기반 TARGET_USER_ID 세팅
- 멱등 / DELETED 상태 전이 실패 케이스 포함
---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. 

---

## 💬 리뷰어에게
- DELETED 상태를 종결 상태로 두고 복구(restore)는 별도 task로 분리해도 괜찮을지 의견 부탁드립니다.
- 현재 응답은 변경된 상태(status)만 반환하도록 최소화했는데, 추후 확장 시 응답 필드 구성 방향성도 코멘트 부탁드립니다.