### PR TITLE
[feat] 결제 검증 API 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/Enrollment.java
@@ -1,0 +1,67 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.entity;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수강 등록(Enrollment) 엔티티입니다.
+ * <p>
+ * 강의(course)와 수강생(student)의 관계를 저장하며,
+ * 수강 상태(status), 수강 시작 시각(enrolledAt), 취소 시각(canceledAt)을 관리합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	name = "enrollments",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_enrollment_course_user_id", columnNames = {"course_id", "user_id"})
+	}
+)
+public class Enrollment extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "course_id", nullable = false)
+	private Course course;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	private EnrollmentStatus status = EnrollmentStatus.ENROLLED;
+
+	@Builder
+	private Enrollment(Course course, User user) {
+		this.course = course;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/EnrollmentStatus.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/EnrollmentStatus.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.entity;
+
+/**
+ * 수강 상태 열거형.
+ * <p>
+ * 사용자의 강의 수강 상태를 구분하기 위한 상태 값들을 정의한다.
+ * 등록/취소
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+
+public enum EnrollmentStatus {
+	ENROLLED,
+	CANCELLED
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *   강의 수강 등록(enrollment) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum.
+ * <p>
+ * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Getter
+@RequiredArgsConstructor
+public enum EnrollmentErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND("EN001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+	ORDER_NOT_FOUND("EN002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCreateListener.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCreateListener.java
@@ -1,0 +1,40 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.service.EnrollmentService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+/**
+ * .
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrollmentCreateListener {
+
+	private final EnrollmentService enrollmentService;
+
+	@Async("paymentAsyncExecutor")
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PaymentConfirmedEvent event) {
+		log.info("[EnrollmentCreateListener] 실행 (orderId={})", event.getOrderId());
+		enrollmentService.createEnrollment(event.getOrderId());
+	}
+}
+

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCreateListener.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCreateListener.java
@@ -7,15 +7,18 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.service.EnrollmentService;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 /**
- * .
+ * 결제 완료 이벤트를 수신하여 강의 수강 등록 생성 리스너.
  * <p>
- *
+ * {@link PaymentConfirmedEvent}가 트랜잭션 커밋 이후(AFTER_COMMIT)에 발행되면
+ *  비동기(@Async)로 실행되며,
+ *  강의 수강 등록 엔티티를 생성하는 책임을 가진다.
  * </p>
  *
  * @author 주우재

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
+
+/**
+ * 강의 수강 등록(enrollment) 엔티티에 대한 데이터 접근을 담당하는 Repository 인터페이스
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,67 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.service;
+
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.exception.EnrollmentErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderItem;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderItemRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 수강 등록 서비스.
+ * <p>
+ * 결제 완료된 주문을 기반으로 수강(Enrollment)을 생성한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnrollmentService {
+
+	private final OrderRepository orderRepository;
+	private final EnrollmentRepository enrollmentRepository;
+	private final OrderItemRepository orderItemRepository;
+
+	@Transactional
+	public void createEnrollment(Long orderId) {
+
+		Order order = getOrder(orderId);
+
+		List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(orderId);
+
+		for (OrderItem item : orderItems) {
+
+			Enrollment enrollment = Enrollment.builder()
+				.course(item.getCourse())
+				.user(order.getUser())
+				.build();
+
+			try {
+				enrollmentRepository.save(enrollment);
+			} catch (DataIntegrityViolationException e) {
+				log.debug("이미 수강 등록이 존재합니다. orderId={}, courseId={}, userId={}",
+					orderId, item.getCourse().getId(), order.getUser().getId());
+			}
+		}
+	}
+
+	private Order getOrder(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(EnrollmentErrorCode.ORDER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/entity/Order.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/entity/Order.java
@@ -67,4 +67,8 @@ public class Order extends BaseTimeEntity {
 	public void updateTotalAmount(BigDecimal totalAmount) {
 		this.totalAmount = totalAmount;
 	}
+
+	public void updateStatus(OrderStatus status) {
+		this.status = status;
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -26,7 +26,8 @@ public enum OrderErrorCode implements ErrorCode {
 	ORDER_NOT_FOUND("OD-003", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
 	UNAUTHORIZED_ACCESS("OD-004", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
 	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST),
-	BAD_PAGING_CONDITION("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+	BAD_PAGING_CONDITION("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+	INVALID_ORDER_STATUS("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -27,7 +27,7 @@ public enum OrderErrorCode implements ErrorCode {
 	UNAUTHORIZED_ACCESS("OD-004", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
 	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST),
 	BAD_PAGING_CONDITION("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-	INVALID_ORDER_STATUS("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+	INVALID_ORDER_STATUS("OD-007", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/listener/OrderUpdateListener.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/listener/OrderUpdateListener.java
@@ -1,0 +1,42 @@
+package com.github.sleeplessspecialist.peaktime.domain.order.listener;
+
+/**
+ * 결제 완료 이벤트를 수신하여 주문 상태를 갱신하는 리스너.
+ *  <p>
+ *  {@link PaymentConfirmedEvent}가 트랜잭션 커밋 이후(AFTER_COMMIT)에 발행되면
+ *  비동기(@Async)로 실행되며,
+ *  결제가 완료된 주문의 상태를 {@code COMPLETED}로 전이시키는 책임을 가진다.
+ *  </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderPaymentCommandService;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderUpdateListener {
+
+	private final OrderPaymentCommandService orderPaymentCommandService;
+
+	@Async("paymentAsyncExecutor")
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PaymentConfirmedEvent event) {
+		log.info("[OrderUpdateListener] 실행 (orderId={})", event.getOrderId());
+		orderPaymentCommandService.markCompleted(event.getOrderId());
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
@@ -2,19 +2,6 @@ package com.github.sleeplessspecialist.peaktime.domain.order.service;
 
 import org.springframework.stereotype.Service;
 
-/**
- * .
- * <p>
- *
- * </p>
- *
- * @author 주우재
- * @version 1.0
- * @since
- */
-
-import org.springframework.stereotype.Service;
-
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
@@ -1,0 +1,81 @@
+package com.github.sleeplessspecialist.peaktime.domain.order.service;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * .
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+
+import org.springframework.stereotype.Service;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
+import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 결제 완료 이후 주문 상태 전이를 담당하는 커맨드 서비스.
+ * <p>
+ * PaymentConfirmedEvent 리스너에서 호출되며,
+ * 주문 상태를 결제 완료 상태로 전이시키는 책임만을 가진다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderPaymentCommandService {
+
+	private final OrderRepository orderRepository;
+
+	/**
+	 * 결제 완료 후처리 로직으로 주문 상태 전이
+	 *
+	 * <p>
+	 * 이미 결제 완료된 주문일 경우 멱등성 보장
+	 * </p>
+	 *
+	 * @param orderId 결제가 완료된 주문 ID
+	 */
+	public void markCompleted(Long orderId) {
+
+		Order order = getOrder(orderId);
+
+		validateStatus(orderId, order);
+
+		order.updateStatus(OrderStatus.COMPLETED);
+	}
+
+	private Order getOrder(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
+	}
+
+	private void validateStatus(Long orderId, Order order) {
+
+		if (order.getStatus() == OrderStatus.COMPLETED) {
+			log.info("이미 결제 완료된 주문입니다. orderId={}", orderId);
+			return;
+		}
+
+		if (order.getStatus() != OrderStatus.PENDING_PAYMENT) {
+			log.warn("결제 완료 처리 불가능한 주문 상태입니다. orderId={}, status={}",
+				orderId, order.getStatus());
+			throw new CustomException(OrderErrorCode.INVALID_ORDER_STATUS);
+		}
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderService.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.github.sleeplessspecialist.peaktime.domain.chat.exception.ChatErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
 import com.github.sleeplessspecialist.peaktime.domain.order.dto.CreateOrderItemReq;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
@@ -41,8 +41,7 @@ public class PaymentController {
 	public ApiResponse<TossPaymentConfirmRes> confirmPayment(@RequestBody @Valid TossPaymentConfirmReq req) {
 		log.info("결제 승인 요청 진입 - orderId: {}", req.getOrderId());
 
-		TossPaymentConfirmRes result = paymentService.confirmPayment(req);
-
-		return ApiResponse.ok(result);
+		paymentService.confirmPayment(req);
+		return ApiResponse.ok();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentConfirmRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentConfirmRes.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
 
+import java.math.BigDecimal;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +26,7 @@ public class TossPaymentConfirmRes {
 	private final String orderName;   // 주문명 (예: "토스 티셔츠 외 2건")
 	private final String status;      // 결제 상태 (DONE, CANCELED, ABORTED, PARTIAL_CANCELED)
 	private final String method;      // 결제 수단 (카드, 가상계좌, 간편결제)
-	private final Long totalAmount;   // 결제된 총 금액
+	private final BigDecimal totalAmount;   // 결제된 총 금액
 	private final String requestedAt; // 결제 요청 시각 (ISO 8601)
 	private final String approvedAt;  // 결제 승인 시각 (ISO 8601)
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Payment.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Payment.java
@@ -1,0 +1,83 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
+
+import java.math.BigDecimal;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+/**
+ * 주문에 대한 결제 정보를 관리하는 엔티티입니다.
+ * <p>
+ * 하나의 결제는 하나의 주문(Order)과 1:1로 매핑되며,
+ * 실제 결제 금액, 결제 수단, 외부 결제 시스템의 트랜잭션 식별자와
+ * 결제 상태를 함께 관리합니다.
+ * <br><br>
+ * 결제 상태는 {@link PaymentStatus}를 통해 관리되며,
+ * 결제 완료 및 환불(부분 환불 포함)과 같은 상태 전이에 사용됩니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+@Entity
+@Table(name = "payments")
+@Getter
+@NoArgsConstructor
+public class Payment extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false, unique = true)
+	private Order order;
+
+	@Column(name = "imp_uid", unique = true, length = 255)
+	private String impUid;
+
+	@Column(name = "amount", nullable = false, precision = 10, scale = 2)
+	private BigDecimal amount;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 50)
+	private PaymentStatus status;
+
+	@Column(name = "payment_method", length = 100)
+	private String paymentMethod;
+
+	@Builder
+	public Payment(Order order, BigDecimal amount, String impUid, PaymentStatus status, String paymentMethod) {
+		this.order = order;
+		this.amount = amount;
+		this.impUid = impUid;
+		this.status = status;
+		this.paymentMethod = paymentMethod;
+	}
+
+	public void completePayment(BigDecimal amount, String method) {
+		this.amount = amount;
+		this.status = PaymentStatus.PAID;
+		this.paymentMethod = method;
+	}
+
+	public void updatePaymentStatus(PaymentStatus status) {
+		this.status = status;
+	}
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,16 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
+
+/**
+ * 결제 상태
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+
+public enum PaymentStatus {
+	PAID, FAILED, REFUNDED
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Refund.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Refund.java
@@ -1,0 +1,59 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
+
+/**
+ * 결제에 대한 환불 정보를 관리하는 엔티티입니다.
+ * <p>
+ * 하나의 결제(Payment)에 대해 여러 건의 환불이 발생할 수 있으며,
+ * 부분 환불 및 전체 환불 이력을 금액과 사유 단위로 저장합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+
+
+import java.math.BigDecimal;
+
+import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refunds")
+@Getter
+@NoArgsConstructor
+public class Refund extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "payment_id")
+	private Payment payment;
+
+	@Column(name = "amount", nullable = false, precision = 10, scale = 2)
+	private BigDecimal amount;
+
+	@Column(name = "reason", columnDefinition = "TEXT")
+	private String reason;
+
+	@Builder
+	public Refund(Payment payment, BigDecimal amount, String reason) {
+		this.payment = payment;
+		this.amount = amount;
+		this.reason = reason;
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Refund.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Refund.java
@@ -12,7 +12,6 @@ package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
  * @since 2026.01.28
  */
 
-
 import java.math.BigDecimal;
 
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
@@ -41,7 +40,7 @@ public class Refund extends BaseTimeEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "payment_id")
+	@JoinColumn(name = "payment_id", nullable = false)
 	private Payment payment;
 
 	@Column(name = "amount", nullable = false, precision = 10, scale = 2)

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/event/PaymentConfirmedEvent.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/event/PaymentConfirmedEvent.java
@@ -1,0 +1,29 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.event;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 결제 승인 완료 시 발행되는 도메인 이벤트 객체입니다.
+ * <p>
+ * 토스 페이먼츠 결제 승인 API 호출이 성공한 이후,
+ * 주문 상태 변경, 포인트 차감, 결제 이력 저장, 알림 발송 등
+ * 후속 비즈니스 로직을 비동기적으로 처리하기 위해 사용됩니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+@Getter
+@Builder
+public class PaymentConfirmedEvent {
+
+	private final Long orderId;
+	private final String paymentKey;
+	private final BigDecimal finalAmount;
+	private final String method;
+	private final Long userId;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 public enum PaymentErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("PM001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	ORDER_NOT_FOUND("PM001", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
+	ORDER_NOT_FOUND("PM002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
@@ -10,6 +10,7 @@ package com.github.sleeplessspecialist.peaktime.domain.payment.exception;
  * @version 1.0
  * @since
  */
+
 import org.springframework.http.HttpStatus;
 
 import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.exception;
+
+/**
+ *  결제(Payment) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum.
+ * <p>
+ * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND("PM001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+	ORDER_NOT_FOUND("PM001", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/listener/PaymentPersistListener.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/listener/PaymentPersistListener.java
@@ -1,0 +1,43 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+import com.github.sleeplessspecialist.peaktime.domain.payment.service.PaymentPersistService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 결제 완료 이벤트를 수신하여 결제 정보를 저장하는 리스너입니다.
+ * <p>
+ * {@link PaymentConfirmedEvent}를 트랜잭션 커밋 이후(AFTER_COMMIT)에
+ * 비동기(@Async)로 처리하며,
+ * 결제 영속화 로직을 {@link PaymentPersistService}에 위임한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentPersistListener {
+
+	private final PaymentPersistService paymentPersistService;
+
+	@Async("paymentAsyncExecutor")
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PaymentConfirmedEvent event) {
+		log.info("[PaymentPersistListener] 실행 (orderId={})", event.getOrderId());
+		paymentPersistService.createPayment(event);
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,18 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
+
+/**
+ * 결제(Payment) 엔티티에 대한 영속성 처리를 담당하는 Repository 인터페이스.
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentPersistService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentPersistService.java
@@ -1,0 +1,71 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.service;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.PaymentStatus;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+import com.github.sleeplessspecialist.peaktime.domain.payment.exception.PaymentErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.payment.repository.PaymentRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 결제 완료 이벤트를 처리하여 결제 정보를 영속화하는 리스너 구현 서비스
+ * <p>
+ * {@link PaymentConfirmedEvent}를 기반으로 Payment 엔티티를 생성하고,
+ * 결제 상태를 완료(PAID)로 저장한다.
+ *
+ * 동일한 주문에 대해 중복 이벤트가 수신될 수 있으므로,
+ * order_id 유니크 제약과 예외 처리(DataIntegrityViolationException)를 통해
+ * 멱등성을 보장한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentPersistService {
+
+	private final PaymentRepository paymentRepository;
+	private final OrderRepository orderRepository;
+
+	/**
+	 * 결제 완료 이벤트를 기반으로 Payment 엔티티 생성후 저장
+	 */
+	@Transactional
+	public void createPayment(PaymentConfirmedEvent event) {
+
+		Order order = getOrder(event);
+
+		Payment payment = Payment.builder()
+			.order(order)
+			.amount(event.getFinalAmount())
+			.paymentMethod(event.getMethod())
+			.status(PaymentStatus.PAID)
+			.impUid(event.getPaymentKey())
+			.build();
+
+		try {
+			paymentRepository.save(payment);
+			log.info("Payment 저장 완료. orderId={}", event.getOrderId());
+		} catch (DataIntegrityViolationException e) {
+			log.debug("이미 Payment가 존재합니다. orderId={}", event.getOrderId());
+		}
+	}
+
+	private Order getOrder(PaymentConfirmedEvent event) {
+		 return orderRepository.findById(event.getOrderId())
+			.orElseThrow(() -> new CustomException(PaymentErrorCode.ORDER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentPersistService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentPersistService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
-import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
 import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
 import com.github.sleeplessspecialist.peaktime.domain.payment.entity.PaymentStatus;
@@ -65,7 +64,7 @@ public class PaymentPersistService {
 	}
 
 	private Order getOrder(PaymentConfirmedEvent event) {
-		 return orderRepository.findById(event.getOrderId())
+		return orderRepository.findById(event.getOrderId())
 			.orElseThrow(() -> new CustomException(PaymentErrorCode.ORDER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
@@ -1,10 +1,20 @@
 package com.github.sleeplessspecialist.peaktime.domain.payment.service;
 
+import java.math.BigDecimal;
+
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmRes;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+import com.github.sleeplessspecialist.peaktime.domain.payment.utill.OrderIdParser;
+import com.github.sleeplessspecialist.peaktime.domain.point.service.PointService;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.infra.payment.TossPaymentClient;
 
 import lombok.RequiredArgsConstructor;
@@ -24,23 +34,38 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PaymentService {
 
+	private final OrderRepository orderRepository;
 	private final TossPaymentClient tossPaymentClient;
+	private final PointService pointService;
+	private final ApplicationEventPublisher eventPublisher;
 
-	/**
-	 * 토스 결제 승인 및 주문 상태 변경
-	 */
 	@Transactional
-	public TossPaymentConfirmRes confirmPayment(TossPaymentConfirmReq req) {
+	public void confirmPayment(TossPaymentConfirmReq req) {
 
-		// 필요한 내부 로직 추가해서 사용하면 됩니다
+		TossPaymentConfirmRes result = tossPaymentClient.confirm(req); // 1) toss 결제 승인 (동기)
 
-		// 외부 API(토스)로 결제 승인 요청
-		TossPaymentConfirmRes result = tossPaymentClient.confirm(req);
+		Long  orderId = Long.valueOf(OrderIdParser.extractOrderId(result.getOrderId()));
+		Order order = getOrder(orderId);
+		Long usePoint = order.getUsePoint().longValueExact();
+		BigDecimal finalAmount = result.getTotalAmount();
 
-		log.info("결제 승인 완료 - orderId: {}, paymentKey: {}", result.getOrderId(), result.getPaymentKey());
-		return result;
+		pointService.spendForOrder(order.getUser(), orderId, usePoint); // 2) 포인트 차감 (동기)
+
+		// 3) 비동기 작업 트리거 (커밋 이후 실행되도록 리스너에서 AFTER_COMMIT 사용)
+		eventPublisher.publishEvent(PaymentConfirmedEvent.builder()
+			.orderId(order.getId())
+			.userId(order.getUser().getId())
+			.paymentKey(result.getPaymentKey())
+			.finalAmount(finalAmount)
+			.method(result.getMethod())
+			.build());
+
+	}
+
+	private Order getOrder(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/utill/OrderIdParser.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/utill/OrderIdParser.java
@@ -1,0 +1,35 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.utill;
+
+/**
+ * Toss 에서 orderId 를 서버 DB 의 orderId로 변환하는 유틸 클래스
+ * <p>
+ * Toss 의 orderId 의 정책상 Base64 최소 6글자 이상 인코딩 형식
+ * ORDER_{DATE}_{orderId}_{RANDOM} 형식의 orderId 에서
+ * 각 데이터를 추출하는 유틸 클래스
+ * extractCreatedAt: Toss 에서 실 결제 시간 추출
+ * extractOrderId: 실제 DB 에 저장된 orderId 추출
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.28
+ */
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class OrderIdParser {
+
+	private static final DateTimeFormatter FORMATTER =
+		DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+	public static LocalDateTime extractCreatedAt(String orderId) {
+		String[] parts = orderId.split("_");
+		return LocalDateTime.parse(parts[1], FORMATTER);
+	}
+
+	public static String extractOrderId(String orderId) {
+		String[] parts = orderId.split("_");
+		return parts[2];
+	}
+}
+

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/entity/PointTransaction.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/entity/PointTransaction.java
@@ -96,6 +96,27 @@ public class PointTransaction extends BaseTimeEntity {
 	}
 
 	/**
+	 * 결제 주문에 따른 포인트 차감 이력을 생성합니다.
+	 *
+	 * @param user         포인트 변동 대상 사용자
+	 * @param usePoint     사용한 포인트 (양수)
+	 * @param orderId      결제 주문 ID
+	 * @param balanceAfter 반영 후 잔액(users.point)
+	 * @return 생성된 포인트 차감 이력 엔티티
+	 */
+	public static PointTransaction paymentUsePoint(User user, Long usePoint, Long orderId, Long balanceAfter) {
+		String dedupKey = "PAYMENT_USE_POINT:ORDER:" + orderId;
+		return new PointTransaction(
+			user,
+			-usePoint, // 차감이므로 음수
+			PointTransactionType.SPEND,
+			balanceAfter,
+			"결제 포인트 사용 (orderId=" + orderId + ")",
+			dedupKey
+		);
+	}
+
+	/**
 	 * 포인트 변동 이력을 생성합니다.
 	 *
 	 * <p>

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/service/PointService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/service/PointService.java
@@ -53,4 +53,32 @@ public class PointService {
 		}
 	}
 
+	/**
+	 * 결제에 사용한 포인트를 차감하고, 이력을 기록합니다.
+	 * <p>
+	 * 동시성/중복 호출로 인해 동일 차감이 두 번 실행될 수 있으므로,
+	 * PointTransaction의 dedupKey 유니크 제약을 통해 1회만 반영되도록 보장합니다.
+	 * </p>
+	 *
+	 * @param user     포인트 차감 대상 사용자
+	 * @param orderId  결제 주문 ID (dedupKey 생성에 사용)
+	 * @param usePoint 사용 포인트 (양수, 0이면 아무 작업도 하지 않음)
+	 */
+	public void spendForOrder(User user, Long orderId, Long usePoint) {
+		if (usePoint == null || usePoint <= 0) {
+			return;
+		}
+
+		long balanceBefore = user.getPoint();
+		long balanceAfter = balanceBefore - usePoint;
+
+		PointTransaction tx = PointTransaction.paymentUsePoint(user, usePoint, orderId, balanceAfter);
+
+		try {
+			pointTransactionRepository.save(tx);
+			user.addPoint(-usePoint); // 차감 반영 (User에 usePoint 메서드가 있으면 그걸로 교체)
+		} catch (DataIntegrityViolationException e) {
+			log.debug("결제 포인트 차감이 이미 처리되었습니다. userId={}, orderId={}", user.getId(), orderId);
+		}
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
@@ -1,9 +1,9 @@
 package com.github.sleeplessspecialist.peaktime.global.config.async;
-
 /**
- * .
+ * 비동기 작업 처리를 위한 Async 설정 클래스.
  * <p>
- *
+ * 결제 후처리 등 비동기 이벤트 리스너에서 사용할
+ * 전용 스레드 풀 Executor를 등록한다.
  * </p>
  *
  * @author 주우재

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
@@ -1,0 +1,35 @@
+package com.github.sleeplessspecialist.peaktime.global.config.async;
+
+/**
+ * .
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+	@Bean(name = "paymentAsyncExecutor")
+	public Executor paymentAsyncExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(8);
+		executor.setMaxPoolSize(16);
+		executor.setQueueCapacity(500);
+		executor.setThreadNamePrefix("payment-async-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -1,75 +1,148 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <script src="https://js.tosspayments.com/v2/standard"></script>
 </head>
 <body>
-<div>
-    <input type="checkbox" id="coupon-box"/>
-    <label for="coupon-box"> 100원 쿠폰 적용 </label>
+
+<!-- 주문 조회 영역 -->
+<div style="margin-bottom: 16px;">
+    <label for="orderId-input" style="display:block; margin-bottom:6px;">
+        주문번호(orderId) 입력
+    </label>
+
+    <input
+            id="orderId-input"
+            type="text"
+            placeholder="예) ORDER_1738048123123_ab12cd34"
+            style="width: 420px; padding: 8px;"
+    />
+
+    <button id="orderId-check-button" style="margin-left: 8px; padding: 8px 12px;">
+        확인
+    </button>
+
+    <!-- 총 결제 금액 표시 -->
+    <div style="margin-top: 12px; padding: 10px; border: 1px solid #ddd; width: 420px;">
+        <strong>총 결제 금액</strong> :
+        <span id="final-amount">-</span> 원
+    </div>
 </div>
-<div id="payment-method"></div>
-<div id="agreement"></div>
-<button class="button" id="payment-button" style="margin-top: 30px">결제하기</button>
+
+<div id="payment-method" style="margin-top: 16px;"></div>
+<div id="agreement" style="margin-top: 16px;"></div>
+
+<button class="button" id="payment-button" style="margin-top: 30px">
+    결제하기
+</button>
 
 <script>
+    const API_BASE_URL = "http://localhost:8080";
+
     main();
 
     async function main() {
+        // DOM 요소
         const button = document.getElementById("payment-button");
-        const coupon = document.getElementById("coupon-box");
-        // ------  결제위젯 초기화 ------
+        const orderIdInput = document.getElementById("orderId-input");
+        const orderIdCheckButton = document.getElementById("orderId-check-button");
+        const finalAmountSpan = document.getElementById("final-amount");
+
+        // Toss 위젯 초기화
         const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
         const tossPayments = TossPayments(clientKey);
-        // 회원 결제
         const customerKey = "oXWHeo1gUCwx-FikAAUCGF";
-        const widgets = tossPayments.widgets({
-            customerKey,
-        });
+        const widgets = tossPayments.widgets({ customerKey });
 
-        // ------ 주문의 결제 금액 설정 ------
-        await widgets.setAmount({
-            currency: "KRW",
-            value: 1000,
-        });
+        /**
+         * 현재 결제 금액 (서버 주문 조회 후 설정됨)
+         */
+        let currentAmount = null;
+        let orderId = null;
+        // 최초 위젯 금액 (임시값)
+        await widgets.setAmount({ currency: "KRW", value: 1000 });
 
         await Promise.all([
-            // ------  결제 UI 렌더링 ------
-            widgets.renderPaymentMethods({
-                selector: "#payment-method",
-                variantKey: "DEFAULT",
-            }),
-            // ------  이용약관 UI 렌더링 ------
-            widgets.renderAgreement({selector: "#agreement", variantKey: "AGREEMENT"}),
+            widgets.renderPaymentMethods({ selector: "#payment-method", variantKey: "DEFAULT" }),
+            widgets.renderAgreement({ selector: "#agreement", variantKey: "AGREEMENT" }),
         ]);
 
-        // ------  주문서의 결제 금액이 변경되었을 경우 결제 금액 업데이트 ------
-        coupon.addEventListener("change", async function () {
-            ㅌ
-            if (coupon.checked) {
-                await widgets.setAmount({
-                    currency: "KRW",
-                    value: 1000 - 100,
-                });
+        /**
+         * 주문 조회
+         * GET /api/v1/orders/{orderId}
+         */
+        orderIdCheckButton.addEventListener("click", async () => {
+            orderId = orderIdInput.value.trim();
 
+            if (!orderId) {
+                alert("orderId를 입력해주세요.");
                 return;
             }
 
-            await widgets.setAmount({
-                currency: "KRW",
-                value: 1000,
-            });
+            try {
+                const response = await fetch(
+                    `${API_BASE_URL}/api/v1/orders/${encodeURIComponent(orderId)}`,
+                    { method: "GET", headers: { Accept: "application/json" } }
+                );
+
+                const json = await response.json().catch(() => ({}));
+
+                if (!response.ok) {
+                    alert("주문 조회 실패: " + JSON.stringify(json));
+                    finalAmountSpan.textContent = "-";
+                    return;
+                }
+
+                const data = json.data ?? json;
+
+                const totalAmount = Number(data.totalAmount);
+                const usePoint = Number(data.usePoint);
+
+                if (!Number.isFinite(totalAmount) || !Number.isFinite(usePoint)) {
+                    alert("서버 응답 형식이 올바르지 않습니다.");
+                    finalAmountSpan.textContent = "-";
+                    return;
+                }
+
+                // ✅ 최종 결제 금액 계산
+                const finalAmount = totalAmount - usePoint;
+                currentAmount = finalAmount;
+
+                // 화면 표시
+                finalAmountSpan.textContent = finalAmount.toLocaleString();
+
+                // ✅ Toss 위젯 결제 금액 동기화
+                await widgets.setAmount({ currency: "KRW", value: finalAmount });
+
+                alert(
+                    `주문 조회 성공\n` +
+                    `totalAmount = ${totalAmount}\n` +
+                    `usePoint = ${usePoint}\n` +
+                    `총 결제 금액 = ${finalAmount}`
+                );
+
+            } catch (err) {
+                console.error(err);
+                alert("주문 조회 중 오류 발생");
+                finalAmountSpan.textContent = "-";
+            }
         });
 
-        // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
-        button.addEventListener("click", async function () {
-            // 결제 버튼을 누를 때마다 새로운 orderId를 생성합니다.
-            const newOrderId = "ORDER-" + generateRandomString();
+        /**
+         * 결제 버튼
+         */
+        button.addEventListener("click", async () => {
+            if (currentAmount === null) {
+                alert("먼저 orderId 조회를 해주세요.");
+                return;
+            }
+
+            const newOrderId = generateSafeOrderId(orderId);
 
             await widgets.requestPayment({
-                orderId: newOrderId, // 여기서 랜덤 ID 사용
-                orderName: "토스 티셔츠 외 2건",
+                orderId: newOrderId,
+                orderName: "벡엔드 개발자를 위한 redis 외 1건",
                 successUrl: window.location.origin + "/success.html",
                 failUrl: window.location.origin + "/fail.html",
                 customerEmail: "customer123@gmail.com",
@@ -79,10 +152,27 @@
         });
     }
 
-    // 랜덤 문자열 생성 함수 (UUID 역할)
-    function generateRandomString() {
-        return window.btoa(Math.random()).slice(0, 20); // 랜덤한 문자열 생성
+    /**
+     * 안전한 orderId: ORDER_{DATE}_{orderId}_{RANDOM}  / orderId 는 실제로 서버 DB 의 orderId
+     */
+    /**
+     * 안전한 orderId 생성
+     * 형식: ORDER_yyyyMMddHHmmss_{orderId}_{random}
+     */
+    function generateSafeOrderId(orderId) {
+        const timestamp = new Date().toISOString()
+            .replace(/[-:.TZ]/g, "")
+            .slice(0, 14); // yyyyMMddHHmmss
+
+        const random = crypto.getRandomValues(new Uint32Array(1))[0]
+            .toString(36)
+            .slice(0, 8);
+
+        return `ORDER_${timestamp}_${orderId}_${random}`;
     }
+
+
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #46 

---

## ✨ 작업 내용

- **토스 결제 승인(confirm) → 내부 후처리(주문 상태/결제 저장/수강 등록/포인트 차감)** 흐름을 정리하고,
- **AFTER_COMMIT + @Async** 기반으로 후처리를 분리하여 응답 시간을 줄였으며,
- **유니크 제약 + 예외 처리**로 중복 이벤트/중복 호출에 대한 **멱등성**을 확보했습니다.

- [x] 기능 추가
- **결제 승인 검증/처리**
  - 토스 결제 승인 API 호출 성공 시 내부 로직 수행 후 `PaymentConfirmedEvent` 발행
  - 토스 `orderId`(ORDER_yyyyMMddHHmmss_{orderId}_{random})에서 **실제 DB orderId 추출**을 위한 `OrderIdParser` 추가

- **결제 후처리 비동기화**
  - 트랜잭션 커밋 이후(AFTER_COMMIT) 비동기 리스너에서 후처리 수행
  - 결제 저장: `PaymentPersistListener` → `PaymentPersistService`
  - 주문 상태 전이: `OrderUpdateListener` → `OrderPaymentCommandService(markCompleted)`
  - 수강 등록 생성: `EnrollmentCreateListener` → `EnrollmentService(createEnrollment)`

- **멱등성/중복 처리**
  - 결제 저장: `payments.order_id` 유니크(1:1) + `DataIntegrityViolationException` 처리로 중복 저장 방지
  - 수강 등록: `(course_id, user_id)` 유니크 + 중복 등록 시 예외 처리로 중복 방지
  - 포인트 차감: `PointTransaction.dedupKey` 기반 유니크 + 중복 차감 방지 (`PAYMENT_USE_POINT:ORDER:{orderId}`)

- **프론트 결제 화면 정리**
  - 주문 조회 후 `totalAmount - usePoint`를 최종 결제 금액으로 표시하고 Toss 위젯 amount 동기화
  - 불필요한 파싱/중복 DOM 렌더링 로직 정리(리팩토링)


---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.
<img width="1868" height="886" alt="image" src="https://github.com/user-attachments/assets/2b5672d8-8c81-44eb-b504-a8f4e1f855f4" />

<img width="1242" height="414" alt="image" src="https://github.com/user-attachments/assets/ccfbb7e6-2b29-4a0f-8ca4-c0d3e865c054" />

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 관련 Issue를 연결했습니다.
- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
결제 시 notice 엔티티를 생성하는 알람 기능은 미포함 상태입니다.
데이터 수집 서버에 api 요청 기능 미포함 상태
테스트 코드 미포함 