### PR TITLE
[feat] 결제 취소 api 구현 

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/entity/Enrollment.java
@@ -1,7 +1,9 @@
 package com.github.sleeplessspecialist.peaktime.domain.enrollment.entity;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.exception.EnrollmentErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -63,5 +65,13 @@ public class Enrollment extends BaseTimeEntity {
 	private Enrollment(Course course, User user) {
 		this.course = course;
 		this.user = user;
+	}
+
+	public void cancelled() {
+		if (this.status == EnrollmentStatus.CANCELLED) return; // 멱등
+		if (this.status != EnrollmentStatus.ENROLLED) {
+			throw new CustomException(EnrollmentErrorCode.INVALID_ENROLLMENT_STATUS);
+		}
+		this.status = EnrollmentStatus.CANCELLED;
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -22,7 +22,8 @@ import lombok.RequiredArgsConstructor;
 public enum EnrollmentErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("EN001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	ORDER_NOT_FOUND("EN002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
+	ORDER_NOT_FOUND("EN002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
+	INVALID_ENROLLMENT_STATUS("EN003", "강의 등록 상태 전이 실패.", HttpStatus.CONFLICT);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCancelListener.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/listener/EnrollmentCancelListener.java
@@ -1,0 +1,47 @@
+package com.github.sleeplessspecialist.peaktime.domain.enrollment.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.service.EnrollmentService;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentCancelledEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 결제 취소 이벤트를 수신하여 강의 수강 상태를 취소로 전이하는 리스너.
+ * <p>
+ * {@link PaymentCancelledEvent}가 트랜잭션 커밋 이후(AFTER_COMMIT)에 발행되면
+ * 비동기(@Async)로 실행되며,
+ * 결제 취소에 따른 수강(enrollment) 상태 전이를 담당한다.
+ * </p>
+ *
+ * <p>
+ * 본 리스너는 결제 취소 트랜잭션과 분리된
+ * 독립적인 트랜잭션(REQUIRES_NEW)에서 실행된다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.31
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrollmentCancelListener {
+
+	private final EnrollmentService enrollmentService;
+
+	@Async("paymentAsyncExecutor")
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PaymentCancelledEvent event) {
+		log.info("[EnrollmentCancelListener] 실행 (orderId={}", event.getOrderId());
+		enrollmentService.cancelEnrollment(event.getUserId(), event.getOrderId());
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.enrollment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
@@ -15,4 +17,6 @@ import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollme
  * @since 2026.01.29
  */
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+	List<Enrollment> findAllByUserIdAndCourseIdIn(Long userId, List<Long> courseIds);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/service/EnrollmentService.java
@@ -60,8 +60,28 @@ public class EnrollmentService {
 		}
 	}
 
+	@Transactional
+	public void cancelEnrollment(Long userId, Long orderId) {
+
+		List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(orderId);
+
+		List<Long> courseIds = orderItems.stream()
+			.map(orderItem -> orderItem.getCourse().getId())
+			.distinct()
+			.toList();
+
+		List<Enrollment> enrollments = enrollmentRepository
+			.findAllByUserIdAndCourseIdIn(userId, courseIds);
+
+		for(Enrollment enrollment : enrollments) {
+			enrollment.cancelled();
+		}
+	}
+
 	private Order getOrder(Long orderId) {
 		return orderRepository.findById(orderId)
 			.orElseThrow(() -> new CustomException(EnrollmentErrorCode.ORDER_NOT_FOUND));
 	}
+
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/entity/Order.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/entity/Order.java
@@ -2,7 +2,9 @@ package com.github.sleeplessspecialist.peaktime.domain.order.entity;
 
 import java.math.BigDecimal;
 
+import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -68,7 +70,19 @@ public class Order extends BaseTimeEntity {
 		this.totalAmount = totalAmount;
 	}
 
-	public void updateStatus(OrderStatus status) {
-		this.status = status;
+	public void complete() {
+		if (this.status == OrderStatus.COMPLETED) return; // 멱등
+		if (this.status != OrderStatus.PENDING_PAYMENT) {
+			throw new CustomException(OrderErrorCode.INVALID_ORDER_STATUS);
+		}
+		this.status = OrderStatus.COMPLETED;
+	}
+
+	public void cancel() {
+		if (this.status == OrderStatus.CANCELLED) return; // 멱등
+		if (this.status != OrderStatus.COMPLETED) {
+			throw new CustomException(OrderErrorCode.INVALID_ORDER_STATUS);
+		}
+		this.status = OrderStatus.CANCELLED;
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/exception/OrderErrorCode.java
@@ -27,7 +27,7 @@ public enum OrderErrorCode implements ErrorCode {
 	UNAUTHORIZED_ACCESS("OD-004", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
 	INSUFFICIENT_POINT("OD-005" ,"포인트가 충분하지 않습니다",  HttpStatus.BAD_REQUEST),
 	BAD_PAGING_CONDITION("OD-006", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-	INVALID_ORDER_STATUS("OD-007", "페이징 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+	INVALID_ORDER_STATUS("OD-007", "주문 상태 전이 실패.", HttpStatus.CONFLICT),;
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/order/service/OrderPaymentCommandService.java
@@ -1,9 +1,9 @@
 package com.github.sleeplessspecialist.peaktime.domain.order.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
-import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
@@ -28,41 +28,26 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderPaymentCommandService {
 
 	private final OrderRepository orderRepository;
-
 	/**
 	 * 결제 완료 후처리 로직으로 주문 상태 전이
-	 *
-	 * <p>
-	 * 이미 결제 완료된 주문일 경우 멱등성 보장
-	 * </p>
-	 *
-	 * @param orderId 결제가 완료된 주문 ID
 	 */
+	@Transactional
 	public void markCompleted(Long orderId) {
-
 		Order order = getOrder(orderId);
+		order.complete();
+	}
 
-		validateStatus(orderId, order);
-
-		order.updateStatus(OrderStatus.COMPLETED);
+	/**
+	 * 결제 취소 후처리 로직으로 주문 상태 전이
+	 */
+	@Transactional
+	public void markCanceled(Long orderId) {
+		Order order = getOrder(orderId);
+		order.cancel();
 	}
 
 	private Order getOrder(Long orderId) {
 		return orderRepository.findById(orderId)
 			.orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
-	}
-
-	private void validateStatus(Long orderId, Order order) {
-
-		if (order.getStatus() == OrderStatus.COMPLETED) {
-			log.info("이미 결제 완료된 주문입니다. orderId={}", orderId);
-			return;
-		}
-
-		if (order.getStatus() != OrderStatus.PENDING_PAYMENT) {
-			log.warn("결제 완료 처리 불가능한 주문 상태입니다. orderId={}, status={}",
-				orderId, order.getStatus());
-			throw new CustomException(OrderErrorCode.INVALID_ORDER_STATUS);
-		}
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
@@ -5,8 +5,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.PaymentCancelReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmReq;
-import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmRes;
 import com.github.sleeplessspecialist.peaktime.domain.payment.service.PaymentService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
@@ -38,10 +38,18 @@ public class PaymentController {
 	 * 프론트엔드(결제 위젯)에서 받은 paymentKey, orderId, amount로 최종 승인을 요청합니다.
 	 */
 	@PostMapping("/confirm")
-	public ApiResponse<TossPaymentConfirmRes> confirmPayment(@RequestBody @Valid TossPaymentConfirmReq req) {
+	public ApiResponse<Void> confirmPayment(@RequestBody @Valid TossPaymentConfirmReq req) {
 		log.info("결제 승인 요청 진입 - orderId: {}", req.getOrderId());
 
 		paymentService.confirmPayment(req);
+		return ApiResponse.ok();
+	}
+
+	@PostMapping("/cancel")
+	public ApiResponse<Void> cancelPayment(@RequestBody @Valid PaymentCancelReq req) {
+		log.info("결제 취소 요청 진입");
+
+		paymentService.cancel(req);
 		return ApiResponse.ok();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/controller/PaymentController.java
@@ -49,7 +49,7 @@ public class PaymentController {
 	public ApiResponse<Void> cancelPayment(@RequestBody @Valid PaymentCancelReq req) {
 		log.info("결제 취소 요청 진입");
 
-		paymentService.cancel(req);
+		paymentService.cancelPayment(req);
 		return ApiResponse.ok();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/PaymentCancelReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/PaymentCancelReq.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+/**
+ *  결제 취소 요청 DTO입니다.
+ * <p>
+ * 결제 키 (paymentKey) 는 필수
+ * 취소 사유(cancelReason)는 필수.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 29.
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class PaymentCancelReq {
+
+	@NotNull
+	private final String paymentKey;
+
+	@NotNull
+	private final String cancelReason;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossCancelInfo.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossCancelInfo.java
@@ -1,0 +1,21 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 토스 결제 취소 내역 DTO입니다.
+ * <p>
+ * cancels 배열의 요소를 매핑합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Getter
+@RequiredArgsConstructor
+public class TossCancelInfo {
+
+	private final String cancelReason;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossCancelInfo.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossCancelInfo.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
 
+import java.math.BigDecimal;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,4 +20,6 @@ import lombok.RequiredArgsConstructor;
 public class TossCancelInfo {
 
 	private final String cancelReason;
+
+	private final BigDecimal cancelAmount;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelReq.java
@@ -1,0 +1,26 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 토스 결제 취소 요청 DTO입니다.
+ * <p>
+ * 취소 사유(cancelReason)는 필수입니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 29.
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class TossPaymentCancelReq {
+
+	@NotNull
+	private final String cancelReason;
+}
+

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelRes.java
@@ -1,5 +1,6 @@
 package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import lombok.Builder;
@@ -34,5 +35,12 @@ public class TossPaymentCancelRes {
 			return null;
 		}
 		return cancels.get(0).getCancelReason();
+	}
+
+	public BigDecimal getCancelAmount() {
+		if (cancels == null || cancels.isEmpty()) {
+			return null;
+		}
+		return cancels.get(0).getCancelAmount();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/dto/TossPaymentCancelRes.java
@@ -1,0 +1,38 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 토스 결제 취소 응답 DTO (필요 필드만 매핑)
+ * <p>
+ * orderId 와 cancels[].cancelReason 정보만 사용합니다.
+ * list[0] = cancelReason
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.29
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class TossPaymentCancelRes {
+
+	private final String orderId;
+	private final List<TossCancelInfo> cancels;
+
+	/**
+	 * 첫 번째 취소 사유 편의 메서드
+	 * 없다면 null 반환
+	 */
+	public String getCancelReason() {
+		if (cancels == null || cancels.isEmpty()) {
+			return null;
+		}
+		return cancels.get(0).getCancelReason();
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Payment.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/entity/Payment.java
@@ -3,6 +3,9 @@ package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
 import java.math.BigDecimal;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
+import com.github.sleeplessspecialist.peaktime.domain.order.entity.OrderStatus;
+import com.github.sleeplessspecialist.peaktime.domain.payment.exception.PaymentErrorCode;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -70,14 +73,12 @@ public class Payment extends BaseTimeEntity {
 		this.paymentMethod = paymentMethod;
 	}
 
-	public void completePayment(BigDecimal amount, String method) {
-		this.amount = amount;
-		this.status = PaymentStatus.PAID;
-		this.paymentMethod = method;
-	}
-
-	public void updatePaymentStatus(PaymentStatus status) {
-		this.status = status;
+	public void refund() {
+		if (status == PaymentStatus.REFUNDED) return;
+		if (status != PaymentStatus.PAID) {
+			throw new CustomException(PaymentErrorCode.INVALID_ORDER_STATUS);
+		}
+		this.status = PaymentStatus.REFUNDED;
 	}
 
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/event/PaymentCancelledEvent.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/event/PaymentCancelledEvent.java
@@ -1,0 +1,26 @@
+package com.github.sleeplessspecialist.peaktime.domain.payment.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 결제 취소가 성공적으로 처리된 이후,
+ * 커밋 완료(트랜잭션 AFTER_COMMIT) 시점에 비동기 후처리를 트리거하기 위한 이벤트.
+ *
+ * <p>
+ * Toss 결제 취소 결과를 기반으로, 수강(enrollment) 상태 전이 등
+ * 외부 시스템/후속 도메인 작업을 비동기로 수행할 때 사용한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 1. 31.
+ */
+@Getter
+@Builder
+public class PaymentCancelledEvent {
+
+	private final Long orderId;
+	private final Long userId;
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/exception/PaymentErrorCode.java
@@ -23,7 +23,9 @@ import lombok.RequiredArgsConstructor;
 public enum PaymentErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("PM001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	ORDER_NOT_FOUND("PM002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND);
+	ORDER_NOT_FOUND("PM002", "존재하지 않는 주문입니다.", HttpStatus.NOT_FOUND),
+	PAYMENT_NOT_FOUND("PM003", "존재하지 않는 결제입니다.", HttpStatus.NOT_FOUND),
+	INVALID_ORDER_STATUS("PM004","결제 상태 전이 실패." , HttpStatus.CONFLICT);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/repository/PaymentRepository.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.payment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
@@ -15,4 +17,6 @@ import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
  * @since 2026.01.28
  */
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+	Optional<Payment> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
@@ -7,16 +7,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
-import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderPaymentCommandService;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.PaymentCancelReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelRes;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmRes;
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
+import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentCancelledEvent;
 import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
+import com.github.sleeplessspecialist.peaktime.domain.payment.exception.PaymentErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.payment.repository.PaymentRepository;
 import com.github.sleeplessspecialist.peaktime.domain.payment.utill.OrderIdParser;
 import com.github.sleeplessspecialist.peaktime.domain.point.service.PointService;
+import com.github.sleeplessspecialist.peaktime.domain.refund.service.RefundService;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 import com.github.sleeplessspecialist.peaktime.global.infra.payment.TossPaymentClient;
 
@@ -30,9 +35,9 @@ import lombok.extern.slf4j.Slf4j;
  * 실제 결제 승인을 수행하고 결과를 반환합니다. 추후 주문 상태 업데이트 로직이 포함됩니다.
  * </p>
  *
- * @author 기섭
- * @version 1.0
- * @since 2026. 1. 26.
+ * @author 기섭, 주우재
+ * @version 1.1
+ * @since 2026. 1. 31.
  */
 @Slf4j
 @Service
@@ -43,6 +48,9 @@ public class PaymentService {
 	private final TossPaymentClient tossPaymentClient;
 	private final PointService pointService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final PaymentRepository paymentRepository;
+	private final OrderPaymentCommandService orderPaymentCommandService;
+	private final RefundService refundService;
 
 	@Transactional
 	public void confirmPayment(TossPaymentConfirmReq req) {
@@ -78,17 +86,34 @@ public class PaymentService {
 
 		Long orderId = Long.valueOf(OrderIdParser.extractOrderId(result.getOrderId()));
 		Order order = getOrder(orderId);
+		Payment payment = getPayment(orderId);
 		String cancelReason = result.getCancelReason();
+		BigDecimal cancelAmount = result.getCancelAmount();
 		Long refundPoint = order.getUsePoint().longValueExact();
 
 		pointService.refundForOrder(order.getUser(), orderId, refundPoint); // 2) 포인트 복구 (동기)
 
-		// 3) 비동기 작업 트리거 (커밋 이후 실행되도록 리스너에서 AFTER_COMMIT 사용)
+		// 4. Payment / Order 상태 전이 (동기)
+		payment.refund();
+		orderPaymentCommandService.markCanceled(orderId);
 
+		// 5. Refund 저장 (동기)
+		refundService.createRefund(payment, cancelAmount, cancelReason);
+
+		// 6) 비동기 작업 트리거 (커밋 이후 실행되도록 리스너에서 AFTER_COMMIT 사용)
+		eventPublisher.publishEvent(PaymentCancelledEvent.builder()
+			.orderId(orderId)
+			.userId(order.getUser().getId())
+			.build());
 	}
 
 	private Order getOrder(Long orderId) {
 		return orderRepository.findById(orderId)
-			.orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
+			.orElseThrow(() -> new CustomException(PaymentErrorCode.ORDER_NOT_FOUND));
+	}
+
+	private Payment getPayment(Long orderId) {
+		return paymentRepository.findByOrderId(orderId)
+			.orElseThrow(() -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
@@ -75,7 +75,7 @@ public class PaymentService {
 	}
 
 	@Transactional
-	public void cancel(PaymentCancelReq req)  {
+	public void cancelPayment(PaymentCancelReq req)  {
 
 		TossPaymentCancelReq tossPaymentCancelReq = TossPaymentCancelReq.builder()
 				.cancelReason(req.getCancelReason())

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/payment/service/PaymentService.java
@@ -9,6 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.github.sleeplessspecialist.peaktime.domain.order.entity.Order;
 import com.github.sleeplessspecialist.peaktime.domain.order.exception.OrderErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.order.repository.OrderRepository;
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.PaymentCancelReq;
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelReq;
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelRes;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmRes;
 import com.github.sleeplessspecialist.peaktime.domain.payment.event.PaymentConfirmedEvent;
@@ -61,6 +64,26 @@ public class PaymentService {
 			.finalAmount(finalAmount)
 			.method(result.getMethod())
 			.build());
+	}
+
+	@Transactional
+	public void cancel(PaymentCancelReq req)  {
+
+		TossPaymentCancelReq tossPaymentCancelReq = TossPaymentCancelReq.builder()
+				.cancelReason(req.getCancelReason())
+				.build();
+
+		// 1) toss 결제 취소(동기)
+		TossPaymentCancelRes result = tossPaymentClient.cancel(req.getPaymentKey(), tossPaymentCancelReq);
+
+		Long orderId = Long.valueOf(OrderIdParser.extractOrderId(result.getOrderId()));
+		Order order = getOrder(orderId);
+		String cancelReason = result.getCancelReason();
+		Long refundPoint = order.getUsePoint().longValueExact();
+
+		pointService.refundForOrder(order.getUser(), orderId, refundPoint); // 2) 포인트 복구 (동기)
+
+		// 3) 비동기 작업 트리거 (커밋 이후 실행되도록 리스너에서 AFTER_COMMIT 사용)
 
 	}
 

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/entity/PointTransaction.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/entity/PointTransaction.java
@@ -96,7 +96,7 @@ public class PointTransaction extends BaseTimeEntity {
 	}
 
 	/**
-	 * 결제 주문에 따른 포인트 차감 이력을 생성합니다.
+	 * 결제 주문에 따른 포인트 차감 이력을 생성한다.
 	 *
 	 * @param user         포인트 변동 대상 사용자
 	 * @param usePoint     사용한 포인트 (양수)
@@ -112,6 +112,33 @@ public class PointTransaction extends BaseTimeEntity {
 			PointTransactionType.SPEND,
 			balanceAfter,
 			"결제 포인트 사용 (orderId=" + orderId + ")",
+			dedupKey
+		);
+	}
+
+	/**
+	 * 결제 취소/환불에 따른 포인트 환급 이력을 생성한다.
+	 *
+	 * <p>
+	 * 결제 시 사용했던 포인트를 환불(복구)할 때 사용.
+	 * amount는 환급이므로 양수(+)로 기록된다.
+	 * </p>
+	 *
+	 * @param user         포인트 변동 대상 사용자
+	 * @param refundPoint  환급할 포인트 (양수)
+	 * @param orderId      결제 주문 ID
+	 * @param balanceAfter 반영 후 잔액(users.point)
+	 * @return 생성된 포인트 환급 이력 엔티티
+	 */
+	public static PointTransaction paymentRefundPoint(User user, Long refundPoint, Long orderId, Long balanceAfter) {
+		String dedupKey = "PAYMENT_REFUND_POINT:ORDER:" + orderId;
+
+		return new PointTransaction(
+			user,
+			refundPoint, // 환급이므로 양수
+			PointTransactionType.REFUND,
+			balanceAfter,
+			"결제 포인트 환불 (orderId=" + orderId + ")",
 			dedupKey
 		);
 	}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/service/PointService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/point/service/PointService.java
@@ -81,4 +81,34 @@ public class PointService {
 			log.debug("결제 포인트 차감이 이미 처리되었습니다. userId={}, orderId={}", user.getId(), orderId);
 		}
 	}
+
+	/**
+	 * 결제 취소(전체 환불) 시 사용 포인트를 환급하고, 이력을 기록합니다.
+	 * <p>
+	 * 전체 환불만 지원하므로 orderId 기준으로 dedupKey를 구성해 1회만 반영되도록 보장합니다.
+	 * (PointTransaction의 dedupKey 유니크 제약 + DataIntegrityViolationException 처리)
+	 * </p>
+	 *
+	 * @param user        포인트 환급 대상 사용자
+	 * @param orderId     결제 주문 ID (dedupKey 생성에 사용)
+	 * @param refundPoint 환급 포인트 (양수, 0이면 아무 작업도 하지 않음)
+	 */
+	public void refundForOrder(User user, Long orderId, Long refundPoint) {
+		if (refundPoint == null || refundPoint <= 0) {
+			return;
+		}
+
+		long balanceBefore = user.getPoint();
+		long balanceAfter = balanceBefore + refundPoint;
+
+		PointTransaction tx = PointTransaction.paymentRefundPoint(user, refundPoint, orderId, balanceAfter);
+
+		try {
+			pointTransactionRepository.save(tx);
+			user.addPoint(refundPoint); // 환급 반영
+		} catch (DataIntegrityViolationException e) {
+			log.debug("결제 포인트 환불이 이미 처리되었습니다. userId={}, orderId={}", user.getId(), orderId);
+		}
+	}
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/entity/Refund.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/entity/Refund.java
@@ -1,4 +1,4 @@
-package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
+package com.github.sleeplessspecialist.peaktime.domain.refund.entity;
 
 /**
  * 결제에 대한 환불 정보를 관리하는 엔티티입니다.
@@ -14,6 +14,7 @@ package com.github.sleeplessspecialist.peaktime.domain.payment.entity;
 
 import java.math.BigDecimal;
 
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -25,12 +26,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "refunds")
+@Table(
+	name = "refunds",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_refund_payment", columnNames = "payment_id")
+	}
+)
 @Getter
 @NoArgsConstructor
 public class Refund extends BaseTimeEntity {

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/exception/RefundErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/exception/RefundErrorCode.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.refund.exception;
+
+/**
+ *  환불(Refund) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum.
+ * <p>
+ * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환한다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.01.31
+ */
+
+import org.springframework.http.HttpStatus;
+
+import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RefundErrorCode implements ErrorCode {
+
+	ALREADY_REFUNDED("RF001", "이미 환불 내역이 존재 합니다.", HttpStatus.CONFLICT);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/repository/RefundRepository.java
@@ -1,0 +1,19 @@
+package com.github.sleeplessspecialist.peaktime.domain.refund.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.refund.entity.Refund;
+
+/**
+ * 환불(Refund) 엔티티에 대한 영속성 처리를 담당하는 Repository 인터페이스.
+ * <p>
+ *
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/service/RefundService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/refund/service/RefundService.java
@@ -1,0 +1,47 @@
+package com.github.sleeplessspecialist.peaktime.domain.refund.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import com.github.sleeplessspecialist.peaktime.domain.payment.entity.Payment;
+import com.github.sleeplessspecialist.peaktime.domain.refund.entity.Refund;
+import com.github.sleeplessspecialist.peaktime.domain.refund.exception.RefundErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.refund.repository.RefundRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 환불(refund) 도메인의 비즈니스 로직을 담당하는 서비스 클래스.
+ * <p>
+ * refund 와 payment 는 1:n 의 연관 관계지만, unique 제약조건으로 1:1 의 멱등성 보장
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since
+ */
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+
+	private final RefundRepository refundRepository;
+
+	public void createRefund(Payment payment, BigDecimal cancelAmount, String cancelReason) {
+
+		try {
+			Refund refund = Refund.builder()
+				.payment(payment)
+				.amount(cancelAmount)
+				.reason(cancelReason)
+				.build();
+
+			refundRepository.save(refund);
+
+		} catch (DataIntegrityViolationException e) {
+			throw new CustomException(RefundErrorCode.ALREADY_REFUNDED);
+		}
+	}
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/async/AsyncConfig.java
@@ -8,7 +8,7 @@ package com.github.sleeplessspecialist.peaktime.global.config.async;
  *
  * @author 주우재
  * @version 1.0
- * @since
+ * @since 2026.01.30
  */
 
 import java.util.concurrent.Executor;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
@@ -11,6 +11,8 @@ import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossErrorDto;
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelReq;
+import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentCancelRes;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmReq;
 import com.github.sleeplessspecialist.peaktime.domain.payment.dto.TossPaymentConfirmRes;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
@@ -83,5 +85,40 @@ public class TossPaymentClient {
 				}
 			})
 			.body(TossPaymentConfirmRes.class);
+	}
+
+
+	/**
+	 * 토스 페이먼츠에 결제 취소를 요청
+	 * <p>
+	 * paymentKey 기준으로 취소 요청을 전송하며, cancelReason 은 필수.
+	 * </p>
+	 *
+	 * @param paymentKey 토스 결제 키
+	 * @param req 취소 요청 바디 (cancelReason 등)
+	 * @return 결제 취소 성공 응답
+	 */
+	public TossPaymentCancelRes cancel(String paymentKey, TossPaymentCancelReq req) {
+		return restClient.post()
+			.uri("/{paymentKey}/cancel", paymentKey)
+			.body(req)
+			.retrieve()
+			.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), (request, response) -> {
+				// 1. 에러 바디 읽기
+				String errorBodyStr = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+
+				// 2. 로그 상세 기록
+				log.error("토스 결제 취소 실패 응답: Status={}, Body={}", response.getStatusCode(), errorBodyStr);
+
+				// 3. 에러 메시지 파싱
+				try {
+					TossErrorDto errorDto = objectMapper.readValue(errorBodyStr, TossErrorDto.class);
+					throw new RuntimeException("토스 결제 실패: " + errorDto.getMessage() + " (" + errorDto.getCode() + ")");
+
+				} catch (Exception e) {
+					throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+				}
+			})
+			.body(TossPaymentCancelRes.class);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
  * 결제 승인 요청(Confirm) 전송, 인증 헤더(Basic Auth) 설정, 그리고 응답 에러 핸들링을 수행합니다.
  * </p>
  *
- * @author 기섭
+ * @author 기섭, 주우재
  * @version 1.0
  * @since 2026. 1. 26.
  */
@@ -86,7 +86,6 @@ public class TossPaymentClient {
 			})
 			.body(TossPaymentConfirmRes.class);
 	}
-
 
 	/**
 	 * 토스 페이먼츠에 결제 취소를 요청


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #49 

---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 간단히 설명해주세요.

금전·상태 정합성은 동기
비즈니스 확장은 비동기
- [ ] 기능 추가
## 결제 후처리 – 동기 처리 (정합성 보장 영역)

결제 취소/환불 시 **반드시 한 트랜잭션 내에서 완료되어야 하는 후처리 로직**을  
아래 순서로 **동기 처리**하도록 구성했습니다.

### 동기 처리 순서

1. **포인트 복구**
   - 주문에 사용된 포인트를 사용자에게 즉시 반환
   - 금전성 데이터이므로 가장 먼저 처리하여 불일치 상태를 방지

2. **결제 상태 전이**
   - `Payment` 상태를 `CANCELED / REFUNDED` 로 전이
   - 외부 결제 결과와 내부 결제 상태를 즉시 일치시킴

3. **주문 상태 전이**
   - 결제 상태 변경에 따라 주문 상태를 `CANCELED` 로 전이
   - 주문은 결제 결과의 직접적인 종속 상태로 취급

4. **환불 내역 생성**
   - 환불 금액 및 사유를 `Refund` 엔티티로 기록
   - 감사/추적을 위한 **이력성 데이터**로 저장

 위 로직은  
**“중간에 실패하면 전체가 롤백되어야 하는 영역”** 으로 판단하여  
단일 트랜잭션 내 동기 처리로 구성했습니다.

##  결제 후처리 – 비동기 처리 (비즈니스 확장 영역)

결제 결과를 기반으로 하지만,  
**결제/환불의 정합성에 직접적인 영향을 주지 않는 로직**은  
비동기 이벤트 기반으로 분리했습니다.

###  비동기 처리 대상

- **강의 수강 등록 상태 전이**
  - 결제 취소/환불 이후 수강 상태를 `CANCELED` 로 전이
  - 결제 트랜잭션과 분리하여 처리하여 장애 전파 방지

 이 처리를 비동기로 분리함으로써
- 결제/환불 API 응답 지연을 방지하고
- 수강 도메인 로직 변경이 결제 흐름에 영향을 주지 않도록 설계했습니다.
---

## 📸 스크린샷 (선택)
주문 취소 후처리
<img width="560" height="77" alt="image" src="https://github.com/user-attachments/assets/2367ce50-9c3f-48ef-b7ff-834d43fd30b1" />

<img width="558" height="107" alt="image" src="https://github.com/user-attachments/assets/38c86be9-14c2-4b66-ac85-6f51b883f5c1" />

<img width="1190" height="67" alt="image" src="https://github.com/user-attachments/assets/5a29f8ef-4c07-4b71-a231-d4ad8f57be5c" />


## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
결제 확정도 결제 취소와 마찬가지로 동기/비동기를 다시 구성하려고 합니다.
해당 내용은 issue #102  에 있습니다.