### PR TITLE
[feat] 리뷰 상세 조회, 내 리뷰 전체 조회, 리뷰 수정, 리뷰 삭제 에 대한 API 구현

### DIFF
--- a/http/review.http
+++ b/http/review.http
@@ -2,6 +2,9 @@
 @host = http://localhost:8080
 @contentType = application/json
 @enrollmentId = 1
+@reviewId = 3
+@page = 1
+@size = 10
 
 ### 리뷰 생성 (인증 제거)
 
@@ -13,3 +16,34 @@ Authorization: Bearer {{accessToken}}
   "rating": 4,
   "content": "전체적으로 만족했습니다."
 }
+
+### 리뷰 상세 조회
+
+GET {{host}}/api/v1/reviews/{{reviewId}}
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+
+### 내 리뷰 목록 조회
+
+GET {{host}}/api/v1/reviews?page={{page}}&size={{size}}
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+### 리뷰 수정 - 권한 없음
+
+PUT {{host}}/api/v1/reviews/{{reviewId}}
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+{
+  "rating": 3,
+  "content": "수정이 잘 반영 되었습니다."
+}
+
+### 리뷰 삭제
+
+DELETE {{host}}/api/v1/reviews/{{reviewId}}
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/controller/ReviewController.java
@@ -1,20 +1,16 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.controller;
 
 
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewReq;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.*;
 import com.github.sleeplessspecialist.peaktime.domain.review.service.ReviewService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 import com.github.sleeplessspecialist.peaktime.global.common.response.SuccessCode;
-import jakarta.validation.constraints.Min;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 리뷰 관련 API를 제공하는 컨트롤러입니다.
@@ -30,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-@Validated
 public class ReviewController {
 
 	private final ReviewService reviewService;
@@ -46,5 +41,55 @@ public class ReviewController {
 
         CreateReviewRes response = reviewService.createReview(userId, enrollmentId, request);
         return ApiResponse.of(SuccessCode.CREATED, response);
+    }
+
+    /**
+     * 리뷰 상세 조회
+     */
+    @GetMapping("/reviews/{reviewId}")
+    public ApiResponse<GetReviewDetailRes> getReviewDetail(
+            @AuthenticationPrincipal Long userId,
+            @Min(1) @PathVariable Long reviewId
+    ) {
+        GetReviewDetailRes response = reviewService.getReviewDetail(userId, reviewId);
+        return ApiResponse.of(SuccessCode.OK, response);
+    }
+
+    /**
+     * 리뷰 목록 조회(내 리뷰)
+     */
+    @GetMapping("/reviews")
+    public ApiResponse<GetReviewListRes> getMyReviews(
+            @AuthenticationPrincipal Long userId,
+            @Min(1) @RequestParam(defaultValue = "1") int page,
+            @Min(1) @Max(50) @RequestParam(defaultValue = "10") int size) {
+
+        GetReviewListRes response = reviewService.getMyReviews(userId, page, size);
+        return ApiResponse.of(SuccessCode.OK, response);
+    }
+
+    /**
+     * 리뷰 수정
+     */
+    @PutMapping("/reviews/{reviewId}")
+    public ApiResponse<UpdateReviewRes> updateReview(
+            @AuthenticationPrincipal Long userId,
+            @Min(1) @PathVariable Long reviewId,
+            @Valid @RequestBody UpdateReviewReq request
+    ) {
+        UpdateReviewRes response = reviewService.updateReview(userId, reviewId, request);
+        return ApiResponse.of(SuccessCode.OK, response);
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @DeleteMapping("/reviews/{reviewId}")
+    public ApiResponse<Void> deleteReview(
+            @AuthenticationPrincipal Long userId,
+            @Min(1) @PathVariable Long reviewId
+    ) {
+        reviewService.deleteReview(userId, reviewId);
+        return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/controller/ReviewController.java
@@ -31,7 +31,7 @@ public class ReviewController {
 	private final ReviewService reviewService;
 
     /**
-     * 수강 생성
+     * 리뷰 생성
      */
     @PostMapping("/enrollments/{enrollmentId}/reviews")
 	public ApiResponse<CreateReviewRes> createReview(

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/CreateReviewReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/CreateReviewReq.java
@@ -3,9 +3,7 @@ package com.github.sleeplessspecialist.peaktime.domain.review.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/GetReviewDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/GetReviewDetailRes.java
@@ -1,0 +1,33 @@
+package com.github.sleeplessspecialist.peaktime.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 리뷰 상세 조회 응답 DTO입니다.
+ * <p>
+ * 리뷰 단건 조회 시, 리뷰 본문/평점과 함께
+ * 어떤 수강 이력(enrollment)과 강의(course)에 속한 리뷰인지 식별할 수 있는 최소 정보를 제공합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.02.04
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class GetReviewDetailRes {
+
+    private final Long reviewId;
+    private final Long userId;
+    private final Long enrollmentId;
+    private final Long courseId;
+    private final Integer rating;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/GetReviewListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/GetReviewListRes.java
@@ -1,0 +1,31 @@
+package com.github.sleeplessspecialist.peaktime.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 리뷰 목록 조회 응답 DTO입니다.
+ * <p>
+ * 리뷰 목록과 페이징 정보를 함께 반환합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.02.04
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class GetReviewListRes {
+
+    private final List<ReviewListItemRes> reviews;
+
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean hasNext;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/ReviewListItemRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/ReviewListItemRes.java
@@ -1,0 +1,44 @@
+package com.github.sleeplessspecialist.peaktime.domain.review.dto;
+
+import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 리뷰 목록 아이템 DTO입니다.
+ * <p>
+ * 목록에서 필요한 최소 정보(리뷰/수강/강의 식별자, 평점, 내용, 작성/수정일)를 제공합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.02.04
+ */
+@Getter
+@Builder
+public class ReviewListItemRes {
+
+    private final Long reviewId;
+    private final Long enrollmentId;
+    private final Long courseId;
+
+    private final Integer rating;
+    private final String content;
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static ReviewListItemRes from(Review review) {
+        return ReviewListItemRes.builder()
+                .reviewId(review.getId())
+                .enrollmentId(review.getEnrollment().getId())
+                .courseId(review.getEnrollment().getCourse().getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/UpdateReviewReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/UpdateReviewReq.java
@@ -1,0 +1,31 @@
+package com.github.sleeplessspecialist.peaktime.domain.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 리뷰 수정 요청 DTO입니다.
+ * <p>
+ * 수정 가능한 필드(평점, 내용)를 전달합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.02.04
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class UpdateReviewReq {
+
+    @Min(1)
+    @Max(5)
+    private final Integer rating;
+
+    @NotBlank
+    private final String content;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/UpdateReviewRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/dto/UpdateReviewRes.java
@@ -1,0 +1,32 @@
+package com.github.sleeplessspecialist.peaktime.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 리뷰 수정 응답 DTO입니다.
+ * <p>
+ * 리뷰 수정 결과를 반환합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.02.04
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class UpdateReviewRes {
+
+    private final Long reviewId;
+    private final Long userId;
+    private final Long enrollmentId;
+    private final Long courseId;
+    private final Integer rating;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/entity/Review.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/entity/Review.java
@@ -2,18 +2,7 @@ package com.github.sleeplessspecialist.peaktime.domain.review.entity;
 
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.global.domain.BaseTimeEntity;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,4 +53,10 @@ public class Review extends BaseTimeEntity {
 		this.rating = rating;
 		this.content = content;
 	}
+
+    public void update(Integer rating, String content) {
+        this.rating = rating;
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/exception/ReviewErrorCode.java
@@ -1,33 +1,31 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.exception;
 
 /**
- *  리뷰 (Review) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum.
+ * 리뷰 (Review) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum.
  * <p>
  * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환한다.
- * </p>
  *
  * @author 주우재
  * @version 1.0
  * @since 2026.02.03
  */
 
-import org.springframework.http.HttpStatus;
-
 import com.github.sleeplessspecialist.peaktime.global.common.error.ErrorCode;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
 
-	USER_NOT_FOUND("RV001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	ENROLLMENT_NOT_FOUND("RV002", "존재하지 않는 수강 등록 입니다.", HttpStatus.NOT_FOUND),
-	UNAUTHORIZED_ACCESS("RV002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
-    REVIEW_ALREADY_EXISTS("RV003", "이미 리뷰가 존재 합니다." , HttpStatus.CONFLICT),;
+    USER_NOT_FOUND("RV001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    ENROLLMENT_NOT_FOUND("RV002", "존재하지 않는 수강 등록 입니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_ACCESS("RV002", "사용자 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+    REVIEW_ALREADY_EXISTS("RV003", "이미 리뷰가 존재 합니다.", HttpStatus.CONFLICT),
+    REVIEW_NOT_FOUND("RV004", "존재하지 않는 리뷰입니다.", HttpStatus.NOT_FOUND);
 
-	private final String code;
-	private final String message;
-	private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
@@ -1,13 +1,15 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.repository;
 
+import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
-
 /**
- *
+ * 리뷰(Review) 엔티티에 대한 영속성 처리를 담당하는 리포지토리입니다.
  * <p>
- *
+ * 리뷰는 수강 이력(Enrollment)에 종속 된다.
  * </p>
  *
  * @author 주우재
@@ -15,4 +17,6 @@ import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
  * @since 2026.02.03
  */
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findAllByEnrollment_User(User user, Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * 리뷰(Review) 엔티티에 대한 영속성 처리를 담당하는 리포지토리입니다.
+ *
  * <p>
  * 리뷰는 수강 이력(Enrollment)에 종속 된다.
  * </p>

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/service/ReviewService.java
@@ -1,22 +1,26 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.service;
 
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewReq;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.*;
 import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
 import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 리뷰 생성/변경과 같은 상태 변경 커맨드를 담당하는 서비스입니다.
@@ -85,6 +89,127 @@ public class ReviewService {
                 .build();
     }
 
+    /**
+     * 리뷰 상세 조회
+     * 1. userId DB 존재 여부 확인
+     * 2. reviewId DB 존재 여부 확인
+     * 3. review 로 인가 검증
+     * 4. 응답 dto 리턴
+     */
+    @Transactional(readOnly = true)
+    public GetReviewDetailRes getReviewDetail(Long userId, Long reviewId) {
+
+        validateUserExists(userId);
+
+        Review review = getReview(reviewId);
+
+        validateReviewOwner(userId, review);
+
+        return GetReviewDetailRes.builder()
+                .reviewId(review.getId())
+                .userId(userId)
+                .enrollmentId(review.getEnrollment().getId())
+                .courseId(review.getEnrollment().getCourse().getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 리뷰 목록 조회 (나의)
+     * 1. userId DB 존재 여부 확인
+     * 2. Pageable 객체 변환
+     * 3. 쿼리메서드 호출후 응답 dto 로 리턴
+     */
+    @Transactional(readOnly = true)
+    public GetReviewListRes getMyReviews(Long userId, int page, int size) {
+
+        User user = getUser(userId);
+
+        Pageable pageable = PageRequest.of(
+                page - 1,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<Review> reviewPage = reviewRepository.findAllByEnrollment_User(user, pageable);
+
+        List<ReviewListItemRes> items = reviewPage.getContent().stream()
+                .map(ReviewListItemRes::from)
+                .toList();
+
+        return GetReviewListRes.builder()
+                .reviews(items)
+                .page(reviewPage.getNumber())
+                .size(reviewPage.getSize())
+                .totalElements(reviewPage.getTotalElements())
+                .totalPages(reviewPage.getTotalPages())
+                .hasNext(reviewPage.hasNext())
+                .build();
+    }
+
+    /**
+     * 리뷰 갱신
+     * 1. userId DB 존재 여부 확인
+     * 2. reviewId DB 존재 여부 확인
+     * 3. review 로 인가 검증
+     * 4. review update
+     * 5. 응답 dto 리턴
+     */
+    @Transactional
+    public UpdateReviewRes updateReview(Long userId, Long reviewId, UpdateReviewReq req) {
+
+        validateUserExists(userId);
+
+        Review review = getReview(reviewId);
+
+        validateReviewOwner(userId, review);
+
+        review.update(req.getRating(), req.getContent());
+
+        return UpdateReviewRes.builder()
+                .reviewId(review.getId())
+                .userId(userId)
+                .enrollmentId(review.getEnrollment().getId())
+                .courseId(review.getEnrollment().getCourse().getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 리뷰 삭제
+     * 1. userId DB 존재 여부 확인
+     * 2. reviewId DB 존재 여부 확인
+     * 3. review 로 인가 검증
+     * 4. review 삭제
+     */
+    @Transactional
+    public void deleteReview(Long userId, Long reviewId) {
+
+        validateUserExists(userId);
+
+        Review review = getReview(reviewId);
+
+        validateReviewOwner(userId, review);
+
+        reviewRepository.delete(review);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ReviewErrorCode.USER_NOT_FOUND));
+    }
+
+    private Review getReview(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ReviewErrorCode.REVIEW_NOT_FOUND));
+    }
+
     private void validateUserExists(Long userId) {
         if (!userRepository.existsById(userId)) {
             log.warn("리뷰 생성 실패 - 존재하지 않는 사용자. userId={}", userId);
@@ -105,8 +230,17 @@ public class ReviewService {
         }
     }
 
+    private void validateReviewOwner(Long userId, Review review) {
+        Long ownerId = review.getEnrollment().getUser().getId();
+        if (!ownerId.equals(userId)) {
+            log.warn("리뷰 조회 실패 - 권한 없음. userId={}, reviewId={}, ownerId={}", userId, review.getId(), ownerId);
+            throw new CustomException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
     private Enrollment getEnrollment(Long enrollmentId) {
         return enrollmentRepository.findById(enrollmentId)
                 .orElseThrow(() -> new CustomException(ReviewErrorCode.ENROLLMENT_NOT_FOUND));
     }
+
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/review/ReviewServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/review/ReviewServiceTest.java
@@ -3,8 +3,7 @@ package com.github.sleeplessspecialist.peaktime.domain.review;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewReq;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.*;
 import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
 import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
@@ -19,10 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -204,6 +208,381 @@ class ReviewServiceTest {
         verify(reviewRepository).save(any(Review.class));
     }
 
+    @Test
+    @DisplayName("리뷰 상세 조회 성공: 본인 리뷰일 경우 상세 정보를 반환한다")
+    void getReviewDetail_Success() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+        Long enrollmentId = 10L;
+        Long courseId = 100L;
+        int rating = 4;
+        String content = "good";
+
+        User student = createUser(userId, "student@test.com");
+        User lecturer = createUser(2L, "lecturer@test.com");
+        Course course = createCourse(courseId, lecturer);
+        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, rating, content, now, now);
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when
+        GetReviewDetailRes result = reviewService.getReviewDetail(userId, reviewId);
+
+        // then
+        assertThat(result.getReviewId()).isEqualTo(reviewId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
+        assertThat(result.getCourseId()).isEqualTo(courseId);
+        assertThat(result.getRating()).isEqualTo(rating);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getCreatedAt()).isEqualTo(now);
+        assertThat(result.getUpdatedAt()).isEqualTo(now);
+
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 상세 조회 실패: 사용자 미존재 시 예외가 발생한다")
+    void getReviewDetail_Fail_UserNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        given(userRepository.existsById(userId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verifyNoInteractions(reviewRepository);
+    }
+
+    @Test
+    @DisplayName("리뷰 상세 조회 실패: 리뷰 미존재 시 예외가 발생한다")
+    void getReviewDetail_Fail_ReviewNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 상세 조회 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+    void getReviewDetail_Fail_Unauthorized() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        User owner = createUser(2L, "owner@test.com");
+        User lecturer = createUser(3L, "lecturer@test.com");
+        Course course = createCourse(100L, lecturer);
+        Enrollment enrollment = createEnrollment(10L, course, owner);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 목록 조회 성공: 사용자 리뷰 목록과 페이지 정보를 반환한다")
+    void getMyReviews_Success() {
+        // given
+        Long userId = 1L;
+        int page = 1;
+        int size = 2;
+
+        User student = createUser(userId, "student@test.com");
+        User lecturer = createUser(2L, "lecturer@test.com");
+        Course course = createCourse(100L, lecturer);
+
+        Enrollment enrollment1 = createEnrollment(10L, course, student);
+        Enrollment enrollment2 = createEnrollment(11L, course, student);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review1 = createReview(1L, enrollment1, 5, "great", now, now);
+        Review review2 = createReview(2L, enrollment2, 3, "ok", now.minusDays(1), now.minusDays(1));
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Review> reviewPage = new PageImpl<>(List.of(review1, review2), pageable, 5);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(student));
+        given(reviewRepository.findAllByEnrollment_User(eq(student), any(Pageable.class))).willReturn(reviewPage);
+
+        // when
+        GetReviewListRes result = reviewService.getMyReviews(userId, page, size);
+
+        // then
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(size);
+        assertThat(result.getTotalElements()).isEqualTo(5);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getReviews()).hasSize(2);
+
+        ReviewListItemRes item1 = result.getReviews().get(0);
+        assertThat(item1.getReviewId()).isEqualTo(1L);
+        assertThat(item1.getEnrollmentId()).isEqualTo(10L);
+        assertThat(item1.getCourseId()).isEqualTo(100L);
+        assertThat(item1.getRating()).isEqualTo(5);
+        assertThat(item1.getContent()).isEqualTo("great");
+        assertThat(item1.getCreatedAt()).isEqualTo(now);
+
+        ReviewListItemRes item2 = result.getReviews().get(1);
+        assertThat(item2.getReviewId()).isEqualTo(2L);
+        assertThat(item2.getEnrollmentId()).isEqualTo(11L);
+        assertThat(item2.getCourseId()).isEqualTo(100L);
+        assertThat(item2.getRating()).isEqualTo(3);
+        assertThat(item2.getContent()).isEqualTo("ok");
+        assertThat(item2.getCreatedAt()).isEqualTo(now.minusDays(1));
+
+        verify(userRepository).findById(userId);
+        verify(reviewRepository).findAllByEnrollment_User(eq(student), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("리뷰 목록 조회 실패: 사용자 미존재 시 예외가 발생한다")
+    void getMyReviews_Fail_UserNotFound() {
+        // given
+        Long userId = 1L;
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.getMyReviews(userId, 1, 10))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+        verify(userRepository).findById(userId);
+        verifyNoInteractions(reviewRepository);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공: 본인 리뷰일 경우 평점과 내용을 갱신한다")
+    void updateReview_Success() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+        Long enrollmentId = 10L;
+        Long courseId = 100L;
+
+        User student = createUser(userId, "student@test.com");
+        User lecturer = createUser(2L, "lecturer@test.com");
+        Course course = createCourse(courseId, lecturer);
+        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, 2, "old", now.minusDays(1), now.minusDays(1));
+
+        UpdateReviewReq req = new UpdateReviewReq(5, "new");
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when
+        UpdateReviewRes result = reviewService.updateReview(userId, reviewId, req);
+
+        // then
+        assertThat(result.getReviewId()).isEqualTo(reviewId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
+        assertThat(result.getCourseId()).isEqualTo(courseId);
+        assertThat(result.getRating()).isEqualTo(5);
+        assertThat(result.getContent()).isEqualTo("new");
+        assertThat(result.getCreatedAt()).isEqualTo(now.minusDays(1));
+        assertThat(result.getUpdatedAt()).isEqualTo(now.minusDays(1));
+        assertThat(review.getRating()).isEqualTo(5);
+        assertThat(review.getContent()).isEqualTo("new");
+
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패: 사용자 미존재 시 예외가 발생한다")
+    void updateReview_Fail_UserNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+        given(userRepository.existsById(userId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verifyNoInteractions(reviewRepository);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패: 리뷰 미존재 시 예외가 발생한다")
+    void updateReview_Fail_ReviewNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+    void updateReview_Fail_Unauthorized() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+        User owner = createUser(2L, "owner@test.com");
+        User lecturer = createUser(3L, "lecturer@test.com");
+        Course course = createCourse(100L, lecturer);
+        Enrollment enrollment = createEnrollment(10L, course, owner);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, 2, "old", now, now);
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공: 본인 리뷰일 경우 삭제가 수행된다")
+    void deleteReview_Success() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        User student = createUser(userId, "student@test.com");
+        User lecturer = createUser(2L, "lecturer@test.com");
+        Course course = createCourse(100L, lecturer);
+        Enrollment enrollment = createEnrollment(10L, course, student);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when
+        reviewService.deleteReview(userId, reviewId);
+
+        // then
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+        verify(reviewRepository).delete(review);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패: 사용자 미존재 시 예외가 발생한다")
+    void deleteReview_Fail_UserNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        given(userRepository.existsById(userId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verifyNoInteractions(reviewRepository);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패: 리뷰 미존재 시 예외가 발생한다")
+    void deleteReview_Fail_ReviewNotFound() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+    void deleteReview_Fail_Unauthorized() {
+        // given
+        Long userId = 1L;
+        Long reviewId = 99L;
+
+        User owner = createUser(2L, "owner@test.com");
+        User lecturer = createUser(3L, "lecturer@test.com");
+        Course course = createCourse(100L, lecturer);
+        Enrollment enrollment = createEnrollment(10L, course, owner);
+
+        LocalDateTime now = LocalDateTime.now();
+        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+        given(userRepository.existsById(userId)).willReturn(true);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+        verify(userRepository).existsById(userId);
+        verify(reviewRepository).findById(reviewId);
+    }
+
     private User createUser(Long id, String email) {
         User user = User.createForSignup("name", email, "pw", "01012345678");
         ReflectionTestUtils.setField(user, "id", id);
@@ -230,5 +609,17 @@ class ReviewServiceTest {
                 .build();
         ReflectionTestUtils.setField(enrollment, "id", id);
         return enrollment;
+    }
+
+    private Review createReview(Long id, Enrollment enrollment, int rating, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        Review review = Review.builder()
+                .enrollment(enrollment)
+                .rating(rating)
+                .content(content)
+                .build();
+        ReflectionTestUtils.setField(review, "id", id);
+        ReflectionTestUtils.setField(review, "createdAt", createdAt);
+        ReflectionTestUtils.setField(review, "updatedAt", updatedAt);
+        return review;
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #55 , #57 , #59 , #62 

---

## ✨ 작업 내용
이번 PR에서는 **강의 수강 후 작성되는 리뷰 기능 전반**을 구현했습니다.

- [ ] 기능 추가 
- 리뷰 단건 상세 조회, 내 리뷰 목록 조회(페이징)를 추가하여  
  사용자가 본인이 작성한 리뷰를 조회할 수 있도록 했습니다.
  - 컨벤션에 따라 Pageable 바인딩이 아닌, 필드로 매핑하게하고, Controller 에서 Bean Validation 을 적용 했습니다.
- 리뷰 평점/내용 수정 기능을 구현해  
  기존 리뷰를 갱신할 수 있도록 했습니다.
   -  해당 review 의 주인만 허용하도록 인가 로직을 포함 시켰습니다.
- 리뷰 삭제 기능을 추가하여  
  더 이상 필요하지 않은 리뷰를 제거할 수 있도록 했습니다.
  -  해당 review 의 주인만 허용하도록 인가 로직을 포함 시켰습니다.

- [ ] 리펙토링
- java docs 보강과, 미사용 import 요청이 있어 반영 했습니다.
---

## 📸 스크린샷 (선택)
- 리뷰 생성 / 조회 / 수정 / 삭제 API 호출 결과
생성
<img width="1444" height="664" alt="image" src="https://github.com/user-attachments/assets/d30e3995-579f-41b8-b08d-0e96af70491d" />
상세 조회
<img width="1116" height="588" alt="image" src="https://github.com/user-attachments/assets/abdb3e0b-87b0-4193-bb10-c52aeab67bdb" />
내 리뷰 전체 조회
<img width="1274" height="666" alt="image" src="https://github.com/user-attachments/assets/8bf95212-93a3-4953-9004-0f2704ec235c" />
수정
<img width="1499" height="795" alt="image" src="https://github.com/user-attachments/assets/9fc5a38c-cf2b-4c18-82c7-769f78d57a9a" />
삭제
<img width="1348" height="489" alt="image" src="https://github.com/user-attachments/assets/fdb4e61d-0656-442e-9d11-cb8bc4a5c06e" />


## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드 및 HTTP Client 스크립트를 추가했습니다.

---

## 💬 리뷰어에게
- 리뷰 삭제 시 **강의 평점 가중치(평균/리뷰 수) 연산은 제외**했습니다.  
  현재 평점 집계는 리뷰 “추가”에만 안전한 구조이므로,  
  수정/삭제까지 정확하게 반영하는 집계 개선은 후속 작업으로 분리하는 것이 적절하다고 판단했습니다.
- 리뷰 수정을 patch 가 아닌 put 으로 한것은 전체 수정이 아닌 부분 수정이기 때문입니다. 
- 전체 구현은 **이전 PR들에서 사용하던 코드 구조와 스타일을 최대한 유지**하여 작성했으며,  
  검증 → 조회 → 인가 → 상태 변경 흐름을 동일한 패턴으로 맞췄습니다.
- 혹시나 컨벤션에 반영되지 않은 내용이 있다면 확인 부탁드립니다.