### PR TITLE
[feat] 지식 공유자 강의 수정, 전체 조회, 상세 조회 API 구현

### DIFF
--- a/http/lecturer-courses.http
+++ b/http/lecturer-courses.http
@@ -1,0 +1,49 @@
+@host = http://localhost:8080
+@token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiaWF0IjoxNzcwMjY0NjAyLCJleHAiOjE3NzAyNjgyMDIsInJvbGUiOiJTVFVERU5UIn0.vucnyIdgpqfIjm9wAobYT7d7Ue4rx2CuWkhz-UHkEJ0
+@contentType = application/json
+
+### 1. 지식공유자 - 강의 등록
+# @name registerCourse
+POST {{host}}/api/v1/lecturer/courses
+Authorization: Bearer {{token}}
+Content-Type: {{contentType}}
+
+{
+  "title": "스프링 부트 핵심 원리",
+  "description": "스프링 부트의 동작 원리를 깊이 있게 학습합니다.",
+  "category": "BACKEND",
+  "price": 55000,
+  "thumbnailUrl": "https://cdn.peaktime.com/spring-boot-thumbnail.jpg"
+}
+
+> {%
+    // 응답에서 생성된 강의 ID를 변수로 저장 (다음 요청에서 쓰기 위해)
+    client.global.set("courseId", response.body.data.courseId);
+    client.log("등록된 강의 ID: " + response.body.data.courseId);
+%}
+
+### 2. 지식공유자 - 강의 정보 전체 수정
+PUT {{host}}/api/v1/lecturer/courses/{{courseId}}
+Authorization: Bearer {{token}}
+Content-Type: {{contentType}}
+
+{
+  "title": "스프링 부트 핵심 원리 (개정판)",
+  "description": "최신 버전(3.x) 내용을 반영하여 내용이 보강되었습니다.",
+  "category": "BACKEND",
+  "price": 68000,
+  "thumbnailUrl": "https://cdn.peaktime.com/spring-boot-v3-new.jpg"
+}
+
+### 3. (403 실패) 권한 없는 유저나 다른 강사의 토큰으로 수정 시도
+PUT {{host}}/api/v1/lecturer/courses/{{courseId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiaWF0IjoxNzcwMjY0NjAyLCJleHAiOjE3NzAyNjgyMDIsInJvbGUiOiJTVFVERU5UIn0.vucnyIdgpqfIjm9wAobYT7d7Ue4rx2CuWkhz-UHkEJ0
+Content-Type: {{contentType}}
+
+{
+  "title": "해킹 시도",
+  "description": "이 요청은 실패해야 합니다.",
+  "category": "HACKING",
+  "price": 0,
+  "thumbnailUrl": "null"
+}

--- a/http/lecturer-courses.http
+++ b/http/lecturer-courses.http
@@ -67,3 +67,33 @@ Content-Type: {{contentType}}
         }
     });
 %}
+
+### 5. 내 강의 상세 조회
+GET {{host}}/api/v1/lecturer/courses/{{courseId}}
+Authorization: Bearer {{token}}
+Content-Type: {{contentType}}
+
+> {%
+    client.test("Status is 200", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+
+    client.test("상세 정보 검증", function () {
+        var data = response.body.data;
+        client.log("강의 제목: " + data.title);
+        client.log("강의 설명: " + data.description);
+        client.log("등록일: " + data.createdAt); // 상세 조회에만 있는 필드 확인
+    });
+%}
+
+### 6. (실패) 존재하지 않거나 권한 없는 강의 조회
+GET {{host}}/api/v1/lecturer/courses/999999
+Authorization: Bearer {{token}}
+Content-Type: {{contentType}}
+
+> {%
+    client.test("Status is 404 or 403", function () {
+        client.log("실패 응답 코드: " + response.status);
+        client.assert(response.status !== 200, "성공하면 안 되는 요청입니다.");
+    });
+%}

--- a/http/lecturer-courses.http
+++ b/http/lecturer-courses.http
@@ -17,7 +17,6 @@ Content-Type: {{contentType}}
 }
 
 > {%
-    // 응답에서 생성된 강의 ID를 변수로 저장 (다음 요청에서 쓰기 위해)
     client.global.set("courseId", response.body.data.courseId);
     client.log("등록된 강의 ID: " + response.body.data.courseId);
 %}
@@ -47,3 +46,24 @@ Content-Type: {{contentType}}
   "price": 0,
   "thumbnailUrl": "null"
 }
+
+### 4. 내 강의 목록 조회 (페이징)
+GET {{host}}/api/v1/lecturer/courses?page=0&size=5
+Authorization: Bearer {{token}}
+Content-Type: {{contentType}}
+
+> {%
+    client.test("Status is 200", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+
+    client.test("응답 데이터 검증", function () {
+        var content = response.body.data.content;
+        client.log("조회된 강의 수: " + content.length);
+
+        if (content.length > 0) {
+            client.log("첫 번째 강의 제목: " + content[0].title);
+            client.log("강사명: " + content[0].lecturerName);
+        }
+    });
+%}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
@@ -1,26 +1,29 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.service.LecturerCourseService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 /**
  * 지식공유자(Lecturer) 전용 강의 관리 API 컨트롤러입니다.
- * <p>
- * 강의 등록, 수정, 삭제 등 지식공유자 권한(ROLE_LECTURER)이 필요한 기능을 담당합니다.
- * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 27.
  */
 @RestController
@@ -28,18 +31,30 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/lecturer/courses")
 public class LecturerCourseController {
 
-	private final LecturerCourseService LecturerCourseService;
+	private final LecturerCourseService lecturerCourseService;
 
 	/**
-	 * 신규 강의를 등록합니다.
-	 *
-	 * @param req 강의 등록 요청 정보 (제목, 설명, 가격 등)
-	 * @return 등록된 강의 ID를 포함한 응답 객체
+	 * 신규 강의 등록
 	 */
 	@PostMapping
-	public ApiResponse<CourseRegisterRes> registerCourse(@RequestBody @Valid CourseRegisterReq req) {
+	public ApiResponse<CourseRegisterRes> registerCourse(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody @Valid CourseRegisterReq req) {
 
-		CourseRegisterRes response = LecturerCourseService.registerCourse(req);
+		CourseRegisterRes response = lecturerCourseService.registerCourse(userId, req);
 		return ApiResponse.created(response);
+	}
+
+	/**
+	 * 강의 정보 수정
+	 */
+	@PutMapping("/{courseId}")
+	public ApiResponse<CourseUpdateRes> updateCourse(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable @Positive Long courseId,
+		@RequestBody @Valid CourseUpdateReq req) {
+
+		CourseUpdateRes response = lecturerCourseService.updateCourse(userId, courseId, req);
+		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseManagementDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -79,6 +80,18 @@ public class LecturerCourseController {
 
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 		Page<CourseListRes> response = lecturerCourseService.getMyCourses(userId, pageable);
+		return ApiResponse.ok(response);
+	}
+
+	/**
+	 * 내 강의 상세 조회
+	 */
+	@GetMapping("/{courseId}")
+	public ApiResponse<CourseManagementDetailRes> getCourseDetail(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable @Positive Long courseId
+	) {
+		CourseManagementDetailRes response = lecturerCourseService.getCourseDetail(userId, courseId);
 		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/controller/LecturerCourseController.java
@@ -1,13 +1,20 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -16,6 +23,8 @@ import com.github.sleeplessspecialist.peaktime.domain.course.service.LecturerCou
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
@@ -55,6 +64,21 @@ public class LecturerCourseController {
 		@RequestBody @Valid CourseUpdateReq req) {
 
 		CourseUpdateRes response = lecturerCourseService.updateCourse(userId, courseId, req);
+		return ApiResponse.ok(response);
+	}
+
+	/**
+	 * 내 강의 목록 조회
+	 */
+	@GetMapping
+	public ApiResponse<Page<CourseListRes>> getMyCourses(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int size
+	) {
+
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+		Page<CourseListRes> response = lecturerCourseService.getMyCourses(userId, pageable);
 		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseDetailRes.java
@@ -8,11 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 강의 상세 조회 응답 DTO입니다.
- * <p>
- * 강의 기본 정보와 지식공유자(Lecturer) 정보, 커리큘럼(Curriculum)을 포함합니다.
- * 모든 필드는 private final로 선언되어 불변성을 보장합니다.
- * </p>
+ * 강의 상세 조회 시 반환되는 응답 DTO입니다.
  *
  * @author 기섭
  * @version 1.1

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
@@ -2,31 +2,31 @@ package com.github.sleeplessspecialist.peaktime.domain.course.dto;
 
 import java.math.BigDecimal;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
- * 강의 목록 조회 응답 DTO입니다.
- * <p>
- * 리스트 형태이므로 커리큘럼 같은 상세 정보는 제외하고,
- * 썸네일, 제목, 가격, 강사명 등 요약 정보만 포함합니다.
- * </p>
+ * 강의 전체 리스트 조회 응답 DTO입니다.
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 27.
  */
 @Getter
-@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CourseListRes {
 
-	private final Long courseId;
-	private final String title;
-	private final String description;
-	private final String category;
-	private final BigDecimal price;
-	private final String thumbnailUrl;
-	private final Double ratingAvg;
-	private final Integer reviewCount;
-	private final String lecturerName;
+	private Long courseId;
+	private String title;
+	private String description;
+	private String category;
+	private BigDecimal price;
+	private String thumbnailUrl;
+	private Double ratingAvg;
+	private Integer reviewCount;
+	private String lecturerName;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseListRes.java
@@ -2,31 +2,25 @@ package com.github.sleeplessspecialist.peaktime.domain.course.dto;
 
 import java.math.BigDecimal;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
- * 강의 전체 리스트 조회 응답 DTO입니다.
+ * 강의 전체 리스트 조회 응답 DTO
  *
  * @author 기섭
  * @version 1.1
  * @since 2026. 1. 27.
  */
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class CourseListRes {
-
-	private Long courseId;
-	private String title;
-	private String description;
-	private String category;
-	private BigDecimal price;
-	private String thumbnailUrl;
-	private Double ratingAvg;
-	private Integer reviewCount;
-	private String lecturerName;
+public record CourseListRes(
+	Long courseId,
+	String title,
+	String description,
+	String category,
+	BigDecimal price,
+	String thumbnailUrl,
+	Double ratingAvg,
+	Integer reviewCount,
+	String lecturerName
+) {
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
@@ -3,34 +3,27 @@ package com.github.sleeplessspecialist.peaktime.domain.course.dto;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
- * 지식공유자 전용 강의 상세 조회 응답 DTO입니다.
+ * 지식공유자 전용 강의 상세 조회 응답 DTO
  *
  * @author 기섭
  * @version 1.0
  * @since 2026. 2. 5.
  */
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
-public class CourseManagementDetailRes {
-
-	private final Long courseId;
-	private final String title;
-	private final String description;
-	private final String category;
-	private final BigDecimal price;
-	private final String thumbnailUrl;
-	private final Double ratingAvg;
-	private final Integer reviewCount;
-	private final String lecturerName;
-	private final LocalDateTime createdAt;
-	private final LocalDateTime updatedAt;
+public record CourseManagementDetailRes(
+	Long courseId,
+	String title,
+	String description,
+	String category,
+	BigDecimal price,
+	String thumbnailUrl,
+	Double ratingAvg,
+	Integer reviewCount,
+	String lecturerName,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
@@ -10,10 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * CourseManagementDetailRes 클래스입니다.
- * <p>
- * 강의의 모든 상세 정보와 관리용 데이터(등록일, 수정일 등)를 포함합니다.
- * </p>
+ * 지식공유자 전용 강의 상세 조회 응답 DTO입니다.
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseManagementDetailRes.java
@@ -1,0 +1,39 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CourseManagementDetailRes 클래스입니다.
+ * <p>
+ * 강의의 모든 상세 정보와 관리용 데이터(등록일, 수정일 등)를 포함합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 2. 5.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class CourseManagementDetailRes {
+
+	private final Long courseId;
+	private final String title;
+	private final String description;
+	private final String category;
+	private final BigDecimal price;
+	private final String thumbnailUrl;
+	private final Double ratingAvg;
+	private final Integer reviewCount;
+	private final String lecturerName;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterReq.java
@@ -7,9 +7,6 @@ import lombok.NoArgsConstructor;
 
 /**
  * 강의 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
- * <p>
- * 제목, 설명, 카테고리, 가격, 썸네일 URL 정보를 포함합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseRegisterRes.java
@@ -5,10 +5,6 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * 강의 등록 성공 시 반환되는 응답 DTO입니다.
- * <p>
- * 등록된 강의의 식별자(ID)를 클라이언트에게 전달하여,
- * 이후 강의 상세 조회나 영상 업로드 요청 등에 사용할 수 있도록 합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateReq.java
@@ -1,0 +1,43 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CourseUpdateReq 클래스입니다.
+ * <p>
+ * 강의 정보를 수정할 때 사용하는 요청 DTO입니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.1
+ * @since 2026. 2. 3.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseUpdateReq {
+
+	@NotBlank(message = "강의 제목은 필수입니다.")
+	private String title;
+
+	@NotBlank(message = "강의 설명은 필수입니다.")
+	private String description;
+
+	@NotBlank(message = "카테고리는 필수입니다.")
+	private String category;
+
+	@NotNull(message = "가격은 필수입니다.")
+	@Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+	private BigDecimal price;
+
+	private String thumbnailUrl;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateReq.java
@@ -11,10 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * CourseUpdateReq 클래스입니다.
- * <p>
  * 강의 정보를 수정할 때 사용하는 요청 DTO입니다.
- * </p>
  *
  * @author 기섭
  * @version 1.1

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateRes.java
@@ -1,0 +1,30 @@
+package com.github.sleeplessspecialist.peaktime.domain.course.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * CourseUpdateRes 클래스입니다.
+ * <p>
+ * 강의 수정 완료 후, 변경된 강의 정보를 클라이언트에게 반환하는 응답 DTO입니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 2. 5.
+ */
+@Getter
+@Builder
+public class CourseUpdateRes {
+
+	private Long courseId;
+	private String title;
+	private String description;
+	private String category;
+	private BigDecimal price;
+	private String thumbnailUrl;
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CourseUpdateRes.java
@@ -7,10 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * CourseUpdateRes 클래스입니다.
- * <p>
  * 강의 수정 완료 후, 변경된 강의 정보를 클라이언트에게 반환하는 응답 DTO입니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CurriculumDto.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/CurriculumDto.java
@@ -4,10 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * CurriculumDto 클래스입니다.
- * <p>
  * 강의 상세 조회 시 포함되는 커리큘럼(강의 영상 목차) 정보 DTO입니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/LecturerDto.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/dto/LecturerDto.java
@@ -4,10 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 강의 상세 조회 시 포함되는 지식공유자(Lecturer) 정보 DTO입니다.
- * <p>
- * 이전의 Tutor라는 명칭을 제거하고 Lecturer로 통일했습니다.
- * </p>
+ * 강의 상세 정보에 포함되는 지식공유자(Lecturer) 응답 DTO입니다
  */
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -25,11 +25,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 강의(강좌) 정보를 저장하는 엔티티 클래스입니다.
- * <p>
- * 강의 제목, 설명, 가격, 썸네일 및 지식공유자(Lecturer) 정보를 관리합니다.
- * 하나의 강의는 여러 개의 개별 영상(Lecture)을 가집니다.
- * </p>
+ * 강의 정보를 저장하는 엔티티 클래스입니다.
  *
  * @author 기섭
  * @version 1.1

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/entity/Course.java
@@ -83,15 +83,28 @@ public class Course extends BaseTimeEntity {
 		this.lecturer = lecturer;
 	}
 
-    public void updateRatingWeight(int newRating) {
-        if (this.reviewCount == null) this.reviewCount = 0;
-        if (this.ratingAvg == null) this.ratingAvg = 0.0;
+	public void updateRatingWeight(int newRating) {
+		if (this.reviewCount == null)
+			this.reviewCount = 0;
+		if (this.ratingAvg == null)
+			this.ratingAvg = 0.0;
 
-        this.reviewCount += 1;
+		this.reviewCount += 1;
 
-        int n = this.reviewCount;
-        double oldAvg = this.ratingAvg;
+		int n = this.reviewCount;
+		double oldAvg = this.ratingAvg;
 
-        this.ratingAvg = ((oldAvg * (n - 1)) + newRating) / n;
-    }
+		this.ratingAvg = ((oldAvg * (n - 1)) + newRating) / n;
+	}
+
+	/**
+	 * 강의 정보 수정
+	 */
+	public void update(String title, String description, String category, BigDecimal price, String thumbnailUrl) {
+		this.title = title;
+		this.description = description;
+		this.category = category;
+		this.price = price;
+		this.thumbnailUrl = thumbnailUrl;
+	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/exception/CourseErrorCode.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 public enum CourseErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND("C001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-	UNAUTHORIZED_ACCESS("C002", "강의를 등록할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+	UNAUTHORIZED_ACCESS("C002", "해당 강의에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 	COURSE_NOT_FOUND("C003", "존재하지 않는 강의입니다.", HttpStatus.NOT_FOUND);
 
 	private final String code;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -2,6 +2,8 @@ package com.github.sleeplessspecialist.peaktime.domain.course.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +28,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 		   join fetch c.lecturer u
 		   where c.id in :ids""")
 	List<Course> findAllByIdInWithUser(@Param("ids") List<Long> ids);
+
+	/**
+	 * 특정 강사의 강의 목록을 페이징하여 조회
+	 */
+	Page<Course> findAllByLecturerId(Long lecturerId, Pageable pageable);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 
 /**
- * 강의(Course) 엔티티의 데이터베이스 접근 및 영속성 관리를 담당하는 리포지토리입니다.
+ * 강의 엔티티의 데이터베이스 접근 및 영속성 관리를 담당하는 리포지토리입니다.
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/repository/CourseRepository.java
@@ -1,5 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +16,14 @@ import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
  * @since 2026. 1. 22.
  */
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+	/**
+	 * List<Long> courseId 를 fetch join 으로 user 까지 가지고 오기
+	 */
+	@Query("""
+		select c
+		   from Course c
+		   join fetch c.lecturer u
+		   where c.id in :ids""")
+	List<Course> findAllByIdInWithUser(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseService.java
@@ -21,9 +21,6 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * 강의 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
- * <p>
- * 강의 등록, 조회, 수정 등의 실질적인 데이터 처리 흐름을 제어합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.1

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseManagementDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -100,5 +101,33 @@ public class LecturerCourseService {
 			.reviewCount(course.getReviewCount())
 			.lecturerName(course.getLecturer().getName())
 			.build());
+	}
+
+	/**
+	 * 강의 상세 조회
+	 */
+	@Transactional(readOnly = true)
+	public CourseManagementDetailRes getCourseDetail(Long userId, Long courseId) {
+
+		Course course = courseRepository.findById(courseId)
+			.orElseThrow(() -> new CustomException(CourseErrorCode.COURSE_NOT_FOUND));
+
+		if (!course.getLecturer().getId().equals(userId)) {
+			throw new CustomException(CourseErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		return CourseManagementDetailRes.builder()
+			.courseId(course.getId())
+			.title(course.getTitle())
+			.description(course.getDescription())
+			.category(course.getCategory())
+			.price(course.getPrice())
+			.thumbnailUrl(course.getThumbnailUrl())
+			.ratingAvg(course.getRatingAvg())
+			.reviewCount(course.getReviewCount())
+			.lecturerName(course.getLecturer().getName())
+			.createdAt(course.getCreatedAt())
+			.updatedAt(course.getUpdatedAt())
+			.build();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -21,11 +21,8 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
 import lombok.RequiredArgsConstructor;
 
 /**
- * LecturerCourseService 클래스입니다.
- * <p>
  * 지식공유자(Lecturer) 전용 강의 관리 서비스입니다.
  * 강의 등록, 수정, 조회 등의 비즈니스 로직을 담당합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -20,6 +20,18 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * LecturerCourseService 클래스입니다.
+ * <p>
+ * 지식공유자(Lecturer) 전용 강의 관리 서비스입니다.
+ * 강의 등록, 수정, 조회 등의 비즈니스 로직을 담당합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 1. 28.
+ */
+
 @Service
 @RequiredArgsConstructor
 public class LecturerCourseService {

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
@@ -14,17 +16,6 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
 
 import lombok.RequiredArgsConstructor;
 
-/**
- * LecturerCourseService 클래스입니다.
- * <p>
- * 지식공유자(Lecturer) 전용 강의 관리 서비스입니다.
- * 강의 등록, 수정, 삭제 등의 비즈니스 로직을 담당합니다.
- * </p>
- *
- * @author 기섭
- * @version 1.0
- * @since 2026. 1. 28.
- */
 @Service
 @RequiredArgsConstructor
 public class LecturerCourseService {
@@ -33,18 +24,12 @@ public class LecturerCourseService {
 	private final UserRepository userRepository;
 
 	/**
-	 * 새로운 강의를 생성하고 저장합니다.
-	 *
-	 * @param req 강의 등록에 필요한 상세 정보
-	 * @return 저장된 강의의 ID
-	 * @throws CustomException 사용자를 찾을 수 없거나 권한이 없는 경우 예외 발생
+	 * 강의 등록
 	 */
 	@Transactional
-	public CourseRegisterRes registerCourse(CourseRegisterReq req) {
-		// TODO: 추후 SecurityContextHolder를 통해 로그인한 유저 ID를 가져오도록 수정 필요
-		Long mockUserId = 1L;
+	public CourseRegisterRes registerCourse(Long userId, CourseRegisterReq req) {
 
-		User lecturer = userRepository.findById(mockUserId)
+		User lecturer = userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(CourseErrorCode.USER_NOT_FOUND));
 
 		Course course = Course.builder()
@@ -59,5 +44,37 @@ public class LecturerCourseService {
 		Course savedCourse = courseRepository.save(course);
 
 		return new CourseRegisterRes(savedCourse.getId());
+	}
+
+	/**
+	 * 강의 수정
+	 */
+	@Transactional
+	public CourseUpdateRes updateCourse(Long userId, Long courseId, CourseUpdateReq req) {
+
+		Course course = courseRepository.findById(courseId)
+			.orElseThrow(() -> new CustomException(CourseErrorCode.COURSE_NOT_FOUND));
+
+		if (!course.getLecturer().getId().equals(userId)) {
+			throw new CustomException(CourseErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		course.update(
+			req.getTitle(),
+			req.getDescription(),
+			req.getCategory(),
+			req.getPrice(),
+			req.getThumbnailUrl()
+		);
+
+		return CourseUpdateRes.builder()
+			.courseId(course.getId())
+			.title(course.getTitle())
+			.description(course.getDescription())
+			.category(course.getCategory())
+			.price(course.getPrice())
+			.thumbnailUrl(course.getThumbnailUrl())
+			.updatedAt(course.getUpdatedAt())
+			.build();
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseService.java
@@ -1,8 +1,11 @@
 package com.github.sleeplessspecialist.peaktime.domain.course.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -76,5 +79,26 @@ public class LecturerCourseService {
 			.thumbnailUrl(course.getThumbnailUrl())
 			.updatedAt(course.getUpdatedAt())
 			.build();
+	}
+
+	/**
+	 * 본인이 등록한 강의 목록 조회
+	 */
+	@Transactional(readOnly = true)
+	public Page<CourseListRes> getMyCourses(Long userId, Pageable pageable) {
+
+		Page<Course> coursePage = courseRepository.findAllByLecturerId(userId, pageable);
+
+		return coursePage.map(course -> CourseListRes.builder()
+			.courseId(course.getId())
+			.title(course.getTitle())
+			.description(course.getDescription())
+			.category(course.getCategory())
+			.price(course.getPrice())
+			.thumbnailUrl(course.getThumbnailUrl())
+			.ratingAvg(course.getRatingAvg())
+			.reviewCount(course.getReviewCount())
+			.lecturerName(course.getLecturer().getName())
+			.build());
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LectureCreateReq.java
@@ -9,10 +9,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 강의 영상 등록 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
- * <p>
  * 영상 제목(Text)과 실제 영상 파일(MultipartFile)을 포함합니다.
- * 불변성을 위해 Setter를 제거하고 생성자 주입을 사용합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/entity/Lecture.java
@@ -19,10 +19,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 개별 강의 영상 정보를 저장하는 엔티티 클래스입니다.
- * <p>
- * 영상의 제목, URL, 재생 시간(Duration)을 관리하며
- * 특정 Course(강좌)에 소속됩니다.
- * </p>
+ * 특정 강의에 소속됩니다.
  *
  * @author 기섭
  * @version 1.1

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * LectureErrorCode 클래스입니다.
+ * 강의 영상(Lecture) 도메인에서 발생할 수 있는 에러 코드를 정의한 Enum입니다.
  * <p>
  * GlobalExceptionHandler에서 이 코드를 기반으로 적절한 HTTP 상태 코드와 메시지를 반환합니다.
  * </p>

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/repository/LectureRepository.java
@@ -6,9 +6,6 @@ import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
 
 /**
  * 강의 영상(Lecture) 엔티티의 데이터베이스 접근 및 영속성 관리를 담당하는 리포지토리입니다.
- * <p>
- * 영상 정보의 조회, 저장, 삭제 등의 기본적인 CRUD 기능을 제공합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
@@ -39,7 +39,6 @@ public class LectureService {
 	private final CourseRepository courseRepository;
 	private final S3Uploader s3Uploader;
 
-	// 허용할 비디오 확장자 목록
 	private static final List<String> ALLOWED_VIDEO_EXTENSIONS = List.of("mp4", "avi", "mov", "wmv", "mkv");
 
 	/**
@@ -55,17 +54,13 @@ public class LectureService {
 		Course course = courseRepository.findById(courseId)
 			.orElseThrow(() -> new CustomException(GlobalErrorCode.INVALID_REQUEST));
 
-		// 파일 확장자 검증
 		validateVideoFileExtension(req.getVideoFile());
 
-		// S3 업로드 (폴더명: video)
 		String videoUrl = s3Uploader.upload(req.getVideoFile(), "video");
 
 		try {
-			// DB 저장 (별도 트랜잭션)
 			return saveLectureMetadata(course, req.getTitle(), videoUrl);
 		} catch (Exception e) {
-			// 보상 트랜잭션, DB 저장 실패 시 S3에 올라간 파일 삭제
 			log.error("DB 저장 실패로 인한 S3 파일 롤백 수행. url={}", videoUrl);
 			s3Uploader.deleteFile(videoUrl);
 			throw e;
@@ -93,14 +88,12 @@ public class LectureService {
 	private void validateVideoFileExtension(MultipartFile file) {
 		String originalFilename = file.getOriginalFilename();
 
-		// 1. 파일명 자체가 문제가 있는 경우
 		if (originalFilename == null || !originalFilename.contains(".")) {
 			throw new CustomException(LectureErrorCode.INVALID_FILE_NAME);
 		}
 
 		String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
 
-		// 2. 허용되지 않은 확장자인 경우
 		if (!ALLOWED_VIDEO_EXTENSIONS.contains(extension)) {
 			throw new CustomException(LectureErrorCode.INVALID_FILE_EXTENSION);
 		}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/UserProfileRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/UserProfileRes.java
@@ -7,11 +7,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * UserProfileRes 클래스입니다.
- * <p>
  * 내 정보 조회 API 요청 시 반환되는 사용자 프로필 정보를 담는 DTO입니다.
- * 사용자 식별자, 이름, 이메일, 연락처, 프로필 이미지 URL, 포인트, 권한 정보를 포함합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/UserUpdateReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/UserUpdateReq.java
@@ -4,11 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * UserUpdateReq 클래스입니다.
- * <p>
  * 내 정보 수정 요청 시 클라이언트로부터 전달받는 데이터를 담는 DTO입니다.
  * 변경 가능한 정보인 사용자 이름과 연락처 정보를 포함합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/ProfileImage.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/entity/ProfileImage.java
@@ -17,11 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * ProfileImage 클래스입니다.
- * <p>
  * 사용자의 프로필 이미지 정보를 관리하는 엔티티 클래스입니다.
  * 이미지 URL, 대표 이미지 여부(isPrimary)를 저장하며 User 엔티티와 N:1 연관 관계를 맺습니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/UserRepository.java
@@ -6,14 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-
 /**
  * 사용자(User) 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
- * <p>
- * 회원 조회, 저장, 삭제 등의 기본적인 CRUD 기능을 제공합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
@@ -14,11 +14,8 @@ import com.github.sleeplessspecialist.peaktime.global.common.security.util.Secur
 import lombok.RequiredArgsConstructor;
 
 /**
- * UserService 클래스입니다.
- * <p>
  * 사용자(User) 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
  * 현재 로그인한 사용자의 정보 조회 및 수정 기능을 담당합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0
@@ -55,7 +52,6 @@ public class UserService {
 		User user = userRepository.findById(currentUserId)
 			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-		// Dirty Checking (변경 감지)
 		user.updateProfile(req.getName(), req.getPhoneNumber());
 		return UserProfileRes.from(user);
 	}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/payment/TossPaymentClient.java
@@ -37,7 +37,6 @@ public class TossPaymentClient {
 	private final ObjectMapper objectMapper;
 	private final RestClient restClient;
 
-	// 생성자 주입
 	public TossPaymentClient(
 		RestClient.Builder builder,
 		ObjectMapper objectMapper,
@@ -46,7 +45,6 @@ public class TossPaymentClient {
 	) {
 		this.objectMapper = objectMapper;
 
-		// 생성자 내부에서 암호화 및 RestClient 초기화 수행
 		String encodedKey = Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
 
 		this.restClient = builder
@@ -68,22 +66,22 @@ public class TossPaymentClient {
 			.uri("/confirm")
 			.body(req)
 			.retrieve()
-			.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), (request, response) -> {
-				// 1. 에러 바디 읽기
-				String errorBodyStr = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+			.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+				(request, response) -> {
 
-				// 2. 로그 상세 기록
-				log.error("토스 결제 실패 응답: Status={}, Body={}", response.getStatusCode(), errorBodyStr);
+					String errorBodyStr = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
 
-				// 3. 에러 메시지 파싱
-				try {
-					TossErrorDto errorDto = objectMapper.readValue(errorBodyStr, TossErrorDto.class);
-					throw new RuntimeException("토스 결제 실패: " + errorDto.getMessage() + " (" + errorDto.getCode() + ")");
+					log.error("토스 결제 실패 응답: Status={}, Body={}", response.getStatusCode(), errorBodyStr);
 
-				} catch (Exception e) {
-					throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
-				}
-			})
+					try {
+						TossErrorDto errorDto = objectMapper.readValue(errorBodyStr, TossErrorDto.class);
+						throw new RuntimeException(
+							"토스 결제 실패: " + errorDto.getMessage() + " (" + errorDto.getCode() + ")");
+
+					} catch (Exception e) {
+						throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+					}
+				})
 			.body(TossPaymentConfirmRes.class);
 	}
 
@@ -102,22 +100,22 @@ public class TossPaymentClient {
 			.uri("/{paymentKey}/cancel", paymentKey)
 			.body(req)
 			.retrieve()
-			.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), (request, response) -> {
-				// 1. 에러 바디 읽기
-				String errorBodyStr = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+			.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+				(request, response) -> {
 
-				// 2. 로그 상세 기록
-				log.error("토스 결제 취소 실패 응답: Status={}, Body={}", response.getStatusCode(), errorBodyStr);
+					String errorBodyStr = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
 
-				// 3. 에러 메시지 파싱
-				try {
-					TossErrorDto errorDto = objectMapper.readValue(errorBodyStr, TossErrorDto.class);
-					throw new RuntimeException("토스 결제 실패: " + errorDto.getMessage() + " (" + errorDto.getCode() + ")");
+					log.error("토스 결제 취소 실패 응답: Status={}, Body={}", response.getStatusCode(), errorBodyStr);
 
-				} catch (Exception e) {
-					throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
-				}
-			})
+					try {
+						TossErrorDto errorDto = objectMapper.readValue(errorBodyStr, TossErrorDto.class);
+						throw new RuntimeException(
+							"토스 결제 실패: " + errorDto.getMessage() + " (" + errorDto.getCode() + ")");
+
+					} catch (Exception e) {
+						throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+					}
+				})
 			.body(TossPaymentCancelRes.class);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
@@ -51,13 +51,11 @@ public class S3Uploader {
 			throw new CustomException(GlobalErrorCode.INVALID_REQUEST);
 		}
 
-		// 1. 파일 이름 중복 방지를 위한 UUID 생성
 		String originalFilename = file.getOriginalFilename();
 		String uuid = UUID.randomUUID().toString();
 		String fileName = dirName + "/" + uuid + "_" + originalFilename;
 
 		try (InputStream inputStream = file.getInputStream()) {
-			// 2. S3에 파일 업로드 (Spring Cloud AWS 3.0 방식)
 			s3Template.upload(bucket, fileName, inputStream, ObjectMetadata.builder()
 				.contentType(file.getContentType())
 				.build());
@@ -69,7 +67,6 @@ public class S3Uploader {
 			throw new CustomException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
 		}
 
-		// 3. 업로드된 파일의 접근 URL 반환
 		return getFileUrl(fileName);
 	}
 
@@ -77,7 +74,6 @@ public class S3Uploader {
 	 * S3에 저장된 파일의 전체 URL을 가져옵니다.
 	 */
 	private String getFileUrl(String fileName) {
-		// ap-northeast-2 (서울) 기준 URL 형식
 		return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
 	}
 
@@ -89,19 +85,15 @@ public class S3Uploader {
 	 */
 	public void deleteFile(String fileUrl) {
 		try {
-			// 1. URL에서 파일 키(Key) 추출 (예: video/uuid_file.mp4)
 			String splitStr = ".com/";
 			String fileName = fileUrl.substring(fileUrl.lastIndexOf(splitStr) + splitStr.length());
 
-			// 2. 한글 파일명 등을 대비해 디코딩
 			String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
 
-			// 3. S3에서 삭제
 			s3Template.deleteObject(bucket, decodedFileName);
 			log.info("S3 파일 삭제 성공: {}", decodedFileName);
 
 		} catch (Exception e) {
-			// 삭제 실패는 치명적인 에러로 보지 않고 로그만 남김 (나중에 배치로 지울 수도 있음)
 			log.error("S3 파일 삭제 실패: url={}, error={}", fileUrl, e.getMessage());
 		}
 	}

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/auth/AuthServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/auth/AuthServiceTest.java
@@ -68,8 +68,6 @@ public class AuthServiceTest {
 	@Mock
 	private ValueOperations<String, String> valueOperations;
 
-
-
 	/**
 	 * 회원가입 성공 시 내부 로직 테스트
 	 */
@@ -112,7 +110,6 @@ public class AuthServiceTest {
 		verify(pointService).grantSignupBonus(savedUser);
 	}
 
-
 	/**
 	 * 로그인 성공 시 내부 로직 테스트
 	 */
@@ -144,7 +141,7 @@ public class AuthServiceTest {
 		when(jwtProperties.getAccessTokenExpirationMs()).thenReturn(1_800_000L);
 
 		// when
-		LoginRes result = authService.login(request);
+		LoginRes result = authService.login(request, "test-user-agent");
 
 		// then
 		assertThat(result.getAccessToken()).isEqualTo("access-token");
@@ -181,7 +178,7 @@ public class AuthServiceTest {
 		// when
 		CustomException ex = Assertions.<CustomException>assertThrows(
 			CustomException.class,
-			() -> authService.login(request)
+			() -> authService.login(request, "test-user-agent")
 		);
 
 		// then
@@ -213,7 +210,7 @@ public class AuthServiceTest {
 		// when
 		CustomException ex = Assertions.<CustomException>assertThrows(
 			CustomException.class,
-			() -> authService.login(request)
+			() -> authService.login(request, "test-user-agent")
 		);
 
 		// then

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/CourseServiceTest.java
@@ -122,7 +122,7 @@ class CourseServiceTest {
 
 		// then
 		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("이자바");
+		assertThat(result.getContent().get(0).lecturerName()).isEqualTo("이자바");
 
 		verify(courseRepository).findAll(any(Pageable.class));
 	}

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -202,8 +202,8 @@ class LecturerCourseServiceTest {
 
 		// then
 		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 강의");
-		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("나강사");
+		assertThat(result.getContent().get(0).title()).isEqualTo("테스트 강의");
+		assertThat(result.getContent().get(0).lecturerName()).isEqualTo("나강사");
 
 		verify(courseRepository).findAllByLecturerId(userId, pageable);
 	}
@@ -234,10 +234,10 @@ class LecturerCourseServiceTest {
 		CourseManagementDetailRes result = lecturerCourseService.getCourseDetail(userId, courseId);
 
 		// then
-		assertThat(result.getCourseId()).isEqualTo(courseId);
-		assertThat(result.getTitle()).isEqualTo("상세 조회 테스트 강의");
-		assertThat(result.getDescription()).isEqualTo("상세 설명입니다.");
-		assertThat(result.getLecturerName()).isEqualTo("나강사");
+		assertThat(result.courseId()).isEqualTo(courseId);
+		assertThat(result.title()).isEqualTo("상세 조회 테스트 강의");
+		assertThat(result.description()).isEqualTo("상세 설명입니다.");
+		assertThat(result.lecturerName()).isEqualTo("나강사");
 
 		verify(courseRepository).findById(courseId);
 	}

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseManagementDetailRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -205,5 +206,64 @@ class LecturerCourseServiceTest {
 		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("나강사");
 
 		verify(courseRepository).findAllByLecturerId(userId, pageable);
+	}
+
+	@Test
+	@DisplayName("getCourseDetail: 본인의 강의 상세 정보를 조회한다.")
+	void getCourseDetail_Success() {
+		// given
+		Long userId = 1L;
+		Long courseId = 100L;
+
+		User lecturer = User.createForSignup("나강사", "tutor@test.com", "pw", "01011112222");
+		ReflectionTestUtils.setField(lecturer, "id", userId);
+		ReflectionTestUtils.setField(lecturer, "nickname", "나강사");
+
+		Course course = Course.builder()
+			.title("상세 조회 테스트 강의")
+			.description("상세 설명입니다.")
+			.price(BigDecimal.valueOf(50000))
+			.category("DEV")
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", courseId);
+
+		given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+		// when
+		CourseManagementDetailRes result = lecturerCourseService.getCourseDetail(userId, courseId);
+
+		// then
+		assertThat(result.getCourseId()).isEqualTo(courseId);
+		assertThat(result.getTitle()).isEqualTo("상세 조회 테스트 강의");
+		assertThat(result.getDescription()).isEqualTo("상세 설명입니다.");
+		assertThat(result.getLecturerName()).isEqualTo("나강사");
+
+		verify(courseRepository).findById(courseId);
+	}
+
+	@Test
+	@DisplayName("getCourseDetail: 본인의 강의가 아니면 예외가 발생한다.")
+	void getCourseDetail_Fail_Unauthorized() {
+		// given
+		Long myId = 1L;
+		Long otherId = 999L;
+		Long courseId = 100L;
+
+		User otherLecturer = User.createForSignup("남강사", "other@test.com", "pw", "01022223333");
+		ReflectionTestUtils.setField(otherLecturer, "id", otherId);
+
+		Course course = Course.builder()
+			.title("남의 강의")
+			.lecturer(otherLecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", courseId);
+
+		given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+		// when & then
+		assertThatThrownBy(() -> lecturerCourseService.getCourseDetail(myId, courseId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", CourseErrorCode.UNAUTHORIZED_ACCESS);
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -17,16 +17,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.exception.CourseErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 /**
- * LecturerCourseService(지식공유자 전용) 비즈니스 로직 테스트 클래스입니다.
+ * LecturerCourseService(지식공유자 전용) 비즈니스 로직 테스트 클래스
  * <p>
- * 대상 클래스: LecturerCourseService
- * 주요 기능: 강의 등록, 수정, 삭제
+ * 대상: LecturerCourseService
+ * 기능: 강의 등록, 수정
  * </p>
  *
  * @author 기섭
@@ -45,10 +49,11 @@ class LecturerCourseServiceTest {
 	private UserRepository userRepository;
 
 	@Test
-	@DisplayName("성공: 강의 등록 정보를 입력하면 저장 후 생성된 강의 ID를 반환한다.")
+	@DisplayName("registerCourse: 강의 등록 정보를 입력하면 저장 후 생성된 강의 ID를 반환")
 	void registerCourse_Success() {
-
 		// given
+		Long userId = 1L;
+
 		CourseRegisterReq req = new CourseRegisterReq();
 		ReflectionTestUtils.setField(req, "title", "새로운 강의");
 		ReflectionTestUtils.setField(req, "description", "강의 설명입니다.");
@@ -57,24 +62,106 @@ class LecturerCourseServiceTest {
 		ReflectionTestUtils.setField(req, "thumbnailUrl", "https://thumb.jpg");
 
 		User lecturer = User.createForSignup("김강사", "tutor@test.com", "hash", "01099998888");
-		ReflectionTestUtils.setField(lecturer, "id", 1L);
+		ReflectionTestUtils.setField(lecturer, "id", userId);
 
 		Course savedCourse = Course.builder()
 			.title(req.getTitle())
 			.lecturer(lecturer)
 			.build();
-		ReflectionTestUtils.setField(savedCourse, "id", 100L); // DB 저장을 흉내내어 ID 주입
+		ReflectionTestUtils.setField(savedCourse, "id", 100L);
 
-		given(userRepository.findById(1L)).willReturn(Optional.of(lecturer)); // 유저 찾기 성공
-		given(courseRepository.save(any(Course.class))).willReturn(savedCourse); // 저장 성공
+		given(userRepository.findById(userId)).willReturn(Optional.of(lecturer));
+		given(courseRepository.save(any(Course.class))).willReturn(savedCourse);
 
 		// when
-		CourseRegisterRes result = lecturerCourseService.registerCourse(req);
+		CourseRegisterRes result = lecturerCourseService.registerCourse(userId, req);
 
 		// then
 		assertThat(result.getCourseId()).isEqualTo(100L);
-		
-		verify(userRepository).findById(1L);
+
+		verify(userRepository).findById(userId);
 		verify(courseRepository).save(any(Course.class));
+	}
+
+	@Test
+	@DisplayName("updateCourse: 본인 강의를 수정하면 값이 변경되고 결과를 반환")
+	void updateCourse_Success() {
+		// given
+		Long userId = 1L;
+		Long courseId = 100L;
+
+		CourseUpdateReq req = CourseUpdateReq.builder()
+			.title("수정된 제목")
+			.description("수정된 설명")
+			.category("FRONTEND")
+			.price(BigDecimal.valueOf(50000))
+			.thumbnailUrl("https://new-thumb.jpg")
+			.build();
+
+		User lecturer = User.createForSignup("김강사", "test@test.com", "pw", "01012345678");
+		ReflectionTestUtils.setField(lecturer, "id", userId);
+
+		Course course = Course.builder()
+			.title("옛날 제목")
+			.description("옛날 설명")
+			.price(BigDecimal.valueOf(10000))
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", courseId);
+
+		// Mocking
+		given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+		// when
+		CourseUpdateRes result = lecturerCourseService.updateCourse(userId, courseId, req);
+
+		// then
+		assertThat(result.getTitle()).isEqualTo("수정된 제목");
+		assertThat(result.getPrice()).isEqualTo(BigDecimal.valueOf(50000));
+
+		assertThat(course.getTitle()).isEqualTo("수정된 제목");
+		assertThat(course.getDescription()).isEqualTo("수정된 설명");
+		assertThat(course.getCategory()).isEqualTo("FRONTEND");
+	}
+
+	@Test
+	@DisplayName("updateCourse: 본인 강의가 아니면 권한 예외(UNAUTHORIZED_ACCESS)가 발생한다.")
+	void updateCourse_Fail_Unauthorized() {
+		// given
+		Long attackerId = 999L;
+		Long courseId = 100L;
+		Long ownerId = 1L;
+
+		CourseUpdateReq req = new CourseUpdateReq();
+
+		User owner = User.createForSignup("주인", "owner@test.com", "pw", "01000000000");
+		ReflectionTestUtils.setField(owner, "id", ownerId);
+
+		Course course = Course.builder().lecturer(owner).build();
+
+		given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+		// when & then
+		assertThatThrownBy(() -> lecturerCourseService.updateCourse(attackerId, courseId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(CourseErrorCode.UNAUTHORIZED_ACCESS);
+	}
+
+	@Test
+	@DisplayName("updateCourse: 존재하지 않는 강의 ID를 수정하려 하면 예외가 발생한다.")
+	void updateCourse_Fail_NotFound() {
+		// given
+		Long userId = 1L;
+		Long weirdId = 9999L;
+		CourseUpdateReq req = new CourseUpdateReq();
+
+		given(courseRepository.findById(weirdId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> lecturerCourseService.updateCourse(userId, weirdId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(CourseErrorCode.COURSE_NOT_FOUND);
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -37,7 +37,7 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
  * LecturerCourseService(지식공유자 전용) 비즈니스 로직 테스트 클래스
  * <p>
  * 대상: LecturerCourseService
- * 기능: 강의 등록, 수정
+ * 기능: 강의 등록, 수정, 조회
  * </p>
  *
  * @author 기섭
@@ -132,7 +132,7 @@ class LecturerCourseServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateCourse: 본인 강의가 아니면 권한 예외(UNAUTHORIZED_ACCESS)가 발생한다.")
+	@DisplayName("updateCourse: 본인 강의가 아니면 권한 예외(UNAUTHORIZED_ACCESS)가 발생")
 	void updateCourse_Fail_Unauthorized() {
 		// given
 		Long attackerId = 999L;
@@ -156,7 +156,7 @@ class LecturerCourseServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateCourse: 존재하지 않는 강의 ID를 수정하려 하면 예외가 발생한다.")
+	@DisplayName("updateCourse: 존재하지 않는 강의 ID를 수정하려 하면 예외가 발생")
 	void updateCourse_Fail_NotFound() {
 		// given
 		Long userId = 1L;
@@ -173,7 +173,7 @@ class LecturerCourseServiceTest {
 	}
 
 	@Test
-	@DisplayName("getMyCourses: 본인이 등록한 강의 목록을 페이징하여 조회한다.")
+	@DisplayName("getMyCourses: 본인이 등록한 강의 목록을 페이징하여 조회")
 	void getMyCourses_Success() {
 		// given
 		Long userId = 1L;
@@ -209,7 +209,7 @@ class LecturerCourseServiceTest {
 	}
 
 	@Test
-	@DisplayName("getCourseDetail: 본인의 강의 상세 정보를 조회한다.")
+	@DisplayName("getCourseDetail: 본인의 강의 상세 정보를 조회")
 	void getCourseDetail_Success() {
 		// given
 		Long userId = 1L;
@@ -217,7 +217,7 @@ class LecturerCourseServiceTest {
 
 		User lecturer = User.createForSignup("나강사", "tutor@test.com", "pw", "01011112222");
 		ReflectionTestUtils.setField(lecturer, "id", userId);
-		ReflectionTestUtils.setField(lecturer, "nickname", "나강사");
+		ReflectionTestUtils.setField(lecturer, "name", "나강사");
 
 		Course course = Course.builder()
 			.title("상세 조회 테스트 강의")
@@ -243,7 +243,7 @@ class LecturerCourseServiceTest {
 	}
 
 	@Test
-	@DisplayName("getCourseDetail: 본인의 강의가 아니면 예외가 발생한다.")
+	@DisplayName("getCourseDetail: 본인의 강의가 아니면 예외가 발생")
 	void getCourseDetail_Fail_Unauthorized() {
 		// given
 		Long myId = 1L;

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/course/service/LecturerCourseServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,8 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseListRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterReq;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseRegisterRes;
 import com.github.sleeplessspecialist.peaktime.domain.course.dto.CourseUpdateReq;
@@ -163,5 +169,41 @@ class LecturerCourseServiceTest {
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(CourseErrorCode.COURSE_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("getMyCourses: 본인이 등록한 강의 목록을 페이징하여 조회한다.")
+	void getMyCourses_Success() {
+		// given
+		Long userId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+
+		User lecturer = User.createForSignup("나강사", "tutor@test.com", "pw", "01011112222");
+		ReflectionTestUtils.setField(lecturer, "id", userId);
+		ReflectionTestUtils.setField(lecturer, "name", "나강사");
+
+		Course course = Course.builder()
+			.title("테스트 강의")
+			.description("강의 설명")
+			.price(BigDecimal.valueOf(10000))
+			.category("IT")
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", 100L);
+
+		List<Course> courseList = List.of(course);
+		Page<Course> coursePage = new PageImpl<>(courseList, pageable, 1);
+
+		given(courseRepository.findAllByLecturerId(userId, pageable)).willReturn(coursePage);
+
+		// when
+		Page<CourseListRes> result = lecturerCourseService.getMyCourses(userId, pageable);
+
+		// then
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 강의");
+		assertThat(result.getContent().get(0).getLecturerName()).isEqualTo("나강사");
+
+		verify(courseRepository).findAllByLecturerId(userId, pageable);
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
@@ -2,7 +2,6 @@ package com.github.sleeplessspecialist.peaktime.domain.user;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
@@ -27,12 +26,7 @@ import com.github.sleeplessspecialist.peaktime.domain.user.service.UserService;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 /**
- * UserServiceTest 클래스입니다.
- * <p>
  * UserService의 비즈니스 로직(내 정보 조회, 수정)을 검증하는 단위 테스트 클래스입니다.
- * Mockito를 사용하여 Repository와 SecurityContext를 모의(Mocking) 처리하여
- * 외부 의존성 없이 서비스 로직만 독립적으로 테스트합니다.
- * </p>
  *
  * @author 기섭
  * @version 1.0
@@ -49,18 +43,17 @@ class UserServiceTest {
 
 	@AfterEach
 	void tearDown() {
-		// 테스트가 끝날 때마다 시큐리티 컨텍스트 초기화 (다른 테스트 간섭 방지)
+
 		SecurityContextHolder.clearContext();
 	}
 
 	@Test
-	@DisplayName("성공: 내 정보를 조회하면 UserProfileRes가 반환된다.")
+	@DisplayName("성공: 내 정보를 조회하면 UserProfileRes가 반환")
 	void getMyProfile_Success() {
 		// given
 		Long userId = 1L;
-		setupSecurityContext(userId); // 1. 로그인된 상태 모의(Mocking)
+		setupSecurityContext(userId);
 
-		// 엔티티 생성 및 ID 주입 (Reflection 사용)
 		User user = User.createForSignup("테스터", "test@email.com", "pw", "01012345678");
 		ReflectionTestUtils.setField(user, "id", userId);
 
@@ -92,19 +85,17 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("성공: 내 정보를 수정하면 변경된 정보가 반영된다.")
+	@DisplayName("성공: 내 정보를 수정하면 변경된 정보를 반영")
 	void updateMyProfile_Success() {
 		// given
 		Long userId = 1L;
 		setupSecurityContext(userId);
 
-		// 기존 유저 정보
 		User user = User.createForSignup("기존이름", "test@email.com", "pw", "01011112222");
 		ReflectionTestUtils.setField(user, "id", userId);
 
 		given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-		// 수정 요청 DTO 생성
 		UserUpdateReq req = new UserUpdateReq();
 		ReflectionTestUtils.setField(req, "name", "변경한이름");
 		ReflectionTestUtils.setField(req, "phoneNumber", "01099998888");
@@ -113,22 +104,15 @@ class UserServiceTest {
 		UserProfileRes result = userService.updateMyProfile(req);
 
 		// then
-		assertThat(result.getName()).isEqualTo("변경한이름"); // 반환값 검증
+		assertThat(result.getName()).isEqualTo("변경한이름");
 		assertThat(result.getPhoneNumber()).isEqualTo("01099998888");
 
-		// 실제 Entity 값도 변경되었는지 확인 (Dirty Checking 동작 검증)
 		assertThat(user.getName()).isEqualTo("변경한이름");
 	}
 
-	// --- Helper Method ---
-
-	/**
-	 * SecurityUtil이 사용하는 SecurityContextHolder에 가짜 인증 정보를 넣습니다.
-	 * SecurityUtil.getCurrentUserId() 호출 시 userId가 반환되도록 설정합니다.
-	 */
 	private void setupSecurityContext(Long userId) {
 		Authentication authentication = mock(Authentication.class);
-		// Principal을 Long 타입으로 반환하도록 설정 (SecurityUtil 구현에 맞춤)
+
 		when(authentication.getPrincipal()).thenReturn(userId);
 
 		SecurityContext securityContext = mock(SecurityContext.class);


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #58 
- close #56 
- close #60 

---

## ✨ 작업 내용
지식공유자(Lecturer)의 강의 수정 기능을 구현
지식공유자(Lecturer)가 본인이 등록한 강의를 조회하는 기능 

- [x] 기능 추가
- [x] 버그 수정
강의 정보 수정 (PUT /api/v1/lecturer/courses/{courseId})
병합 실수 복구 : CourseRepository: findAllByIdInWithUser복구

- [x] 기능 추가
- [x] 문서 수정
- 내 강의 목록 조회 (GET /api/v1/lecturer/courses)
- 내 강의 상세 조회 (GET /api/v1/lecturer/courses/{courseId})
- 자바독 주석 수정
---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게
- 이전 PR에서 컴플릭트 해결 중 CourseRepository: findAllByIdInWithUser를 지워 CI가 안되는 문제가 있었습니다. 해결해서 강의 수정과 같이 올립니다
- 테스트 코드 작성을 하면서 @AllArgsConstructor를 사용했습니다
- 컨벤션이 부족한 부분에대해 말씀해주시면 수정하겠습니다. 감사합니다
