### PR TITLE
[feat] 프로필 이미지 업로드

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/UserController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/controller/UserController.java
@@ -2,15 +2,20 @@ package com.github.sleeplessspecialist.peaktime.domain.user.controller;
 
 import java.util.List;
 
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.github.sleeplessspecialist.peaktime.domain.order.service.OrderService;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.MyCourseRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.ProfileImageRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserProfileRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserUpdateReq;
 import com.github.sleeplessspecialist.peaktime.domain.user.service.UserService;
@@ -20,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * 사용자 본인의 정보 관리 API를 제공하는 컨트롤러 클래스입니다.
- * 내 정보 조회, 내 정보 수정, 내 강의 목록 조회
+ * 내 정보 조회, 내 정보 수정, 내 강의 목록 조회, 프로필 이미지 업로드
  * </p>
  *
  * @author 기섭
@@ -67,8 +72,20 @@ public class UserController {
 	public ApiResponse<List<MyCourseRes>> getMyCourses(
 		@AuthenticationPrincipal Long userId
 	) {
-		
+
 		List<MyCourseRes> response = userService.getMyCourses(userId);
+		return ApiResponse.ok(response);
+	}
+
+	/**
+	 * 프로필 이미지 업로드
+	 */
+	@PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<ProfileImageRes> uploadProfileImage(
+		@AuthenticationPrincipal Long userId,
+		@RequestPart("file") MultipartFile file
+	) {
+		ProfileImageRes response = userService.uploadProfileImage(userId, file);
 		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/ProfileImageRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/dto/ProfileImageRes.java
@@ -1,0 +1,17 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.dto;
+
+import lombok.Builder;
+
+/**
+ * 프로필 이미지 업로드 요청이 성공했을 때,
+ * 클라이언트에게 업로드된 이미지의 URL 정보를 반환하기 위해 사용됩니다.
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 2. 6.
+ */
+@Builder
+public record ProfileImageRes(
+	String imageUrl
+) {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/exception/UserErrorCode.java
@@ -26,6 +26,9 @@ public enum UserErrorCode implements ErrorCode {
 	DUPLICATE_EMAIL("U002", "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
 	PASSWORD_NOT_MATCH("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 	ALREADY_DELETED_USER("U004", "이미 탈퇴한 회원입니다.", HttpStatus.BAD_REQUEST),
+	PROFILE_IMAGE_TOO_LARGE("U005", "프로필 이미지는 5MB를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	INVALID_PROFILE_IMAGE_TYPE("U006", "이미지 파일만 업로드할 수 있습니다.", HttpStatus.BAD_REQUEST),
+	EMPTY_FILE_EXCEPTION("U007", "파일이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 	INVALID_STATUS_TRANSITION("U400", "INVALID_STATUS_TRANSITION", HttpStatus.BAD_REQUEST);
 
 	private final String code;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/ProfileImageRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/repository/ProfileImageRepository.java
@@ -1,0 +1,19 @@
+package com.github.sleeplessspecialist.peaktime.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.ProfileImage;
+
+/**
+ * 사용자의 프로필 이미지 정보를 관리하는 레포지토리입니다.
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 2. 6.
+ */
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
+	Optional<ProfileImage> findByUserIdAndIsPrimaryTrue(Long userId);
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
@@ -22,6 +22,7 @@ import com.github.sleeplessspecialist.peaktime.global.common.error.CustomExcepti
 import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 사용자(User) 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
  * @version 1.2
  * @since 2026. 1. 28.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -106,16 +108,24 @@ public class UserService {
 		String dirName = "users/" + userId + "/profile";
 		String imageUrl = s3Uploader.upload(file, dirName);
 
-		profileImageRepository.findByUserIdAndIsPrimaryTrue(userId)
-			.ifPresent(oldImage -> oldImage.setPrimary(false));
+		try {
+			profileImageRepository.findByUserIdAndIsPrimaryTrue(userId)
+				.ifPresent(oldImage -> oldImage.setPrimary(false));
 
-		ProfileImage newImage = ProfileImage.builder()
-			.url(imageUrl)
-			.isPrimary(true)
-			.user(user)
-			.build();
+			ProfileImage newImage = ProfileImage.builder()
+				.url(imageUrl)
+				.isPrimary(true)
+				.user(user)
+				.build();
 
-		profileImageRepository.save(newImage);
+			profileImageRepository.save(newImage);
+
+		} catch (RuntimeException e) {
+			log.error("DB 저장 실패로 인한 S3 이미지 삭제: {}", imageUrl);
+			s3Uploader.deleteFile(imageUrl);
+
+			throw e;
+		}
 
 		return ProfileImageRes.builder()
 			.imageUrl(imageUrl)

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
@@ -4,23 +4,29 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.EnrollmentStatus;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.MyCourseRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.ProfileImageRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserProfileRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserUpdateReq;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.ProfileImage;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import com.github.sleeplessspecialist.peaktime.domain.user.exception.UserErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.ProfileImageRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
 
 import lombok.RequiredArgsConstructor;
 
 /**
  * 사용자(User) 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
  * 현재 로그인한 사용자의 정보 조회, 수정 및 수강 목록 조회를 담당합니다.
+ * 프로필 이미지 업로드
  *
  * @author 기섭
  * @version 1.2
@@ -31,7 +37,11 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final ProfileImageRepository profileImageRepository;
 	private final EnrollmentRepository enrollmentRepository;
+	private final S3Uploader s3Uploader;
+
+	private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
 	/**
 	 * 내 정보 조회
@@ -63,7 +73,7 @@ public class UserService {
 	 */
 	@Transactional(readOnly = true)
 	public List<MyCourseRes> getMyCourses(Long userId) {
-		
+
 		List<Enrollment> enrollments = enrollmentRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
 			userId, EnrollmentStatus.ENROLLED);
 
@@ -77,5 +87,61 @@ public class UserService {
 				.enrolledAt(enrollment.getCreatedAt())
 				.build())
 			.toList();
+	}
+
+	/**
+	 * 프로필 이미지 업로드
+	 * 1. S3 업로드
+	 * 2. 기존 대표 이미지 해제 (History 유지)
+	 * 3. 새 이미지 대표 설정 및 저장
+	 */
+	@Transactional
+	public ProfileImageRes uploadProfileImage(Long userId, MultipartFile file) {
+
+		validateProfileImage(file);
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		String dirName = "users/" + userId + "/profile";
+		String imageUrl = s3Uploader.upload(file, dirName);
+
+		profileImageRepository.findByUserIdAndIsPrimaryTrue(userId)
+			.ifPresent(oldImage -> oldImage.setPrimary(false));
+
+		ProfileImage newImage = ProfileImage.builder()
+			.url(imageUrl)
+			.isPrimary(true)
+			.user(user)
+			.build();
+
+		profileImageRepository.save(newImage);
+
+		return ProfileImageRes.builder()
+			.imageUrl(imageUrl)
+			.build();
+	}
+
+	/**
+	 * 내부 메서드: 프로필 이미지 유효성 검사
+	 * 1. 빈 파일 체크
+	 * 2. 용량 체크 (5MB 제한)
+	 * 3. 파일 형식 체크 (이미지 여부)
+	 * * @param file 업로드된 파일
+	 */
+	private void validateProfileImage(MultipartFile file) {
+
+		if (file.isEmpty()) {
+			throw new CustomException(UserErrorCode.EMPTY_FILE_EXCEPTION);
+		}
+
+		if (file.getSize() > MAX_IMAGE_SIZE) {
+			throw new CustomException(UserErrorCode.PROFILE_IMAGE_TOO_LARGE);
+		}
+
+		String contentType = file.getContentType();
+		if (contentType == null || !contentType.startsWith("image")) {
+			throw new CustomException(UserErrorCode.INVALID_PROFILE_IMAGE_TYPE);
+		}
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
@@ -15,20 +15,27 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.EnrollmentStatus;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.MyCourseRes;
+import com.github.sleeplessspecialist.peaktime.domain.user.dto.ProfileImageRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserProfileRes;
 import com.github.sleeplessspecialist.peaktime.domain.user.dto.UserUpdateReq;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.ProfileImage;
 import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import com.github.sleeplessspecialist.peaktime.domain.user.exception.UserErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.ProfileImageRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.service.UserService;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
+import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -41,6 +48,12 @@ class UserServiceTest {
 
 	@Mock
 	private EnrollmentRepository enrollmentRepository;
+
+	@Mock
+	private ProfileImageRepository profileImageRepository;
+
+	@Mock
+	private S3Uploader s3Uploader;
 
 	@Test
 	@DisplayName("성공: 내 정보를 조회하면 UserProfileRes가 반환된다.")
@@ -134,5 +147,100 @@ class UserServiceTest {
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("성공: 프로필 이미지를 업로드하면 S3에 저장되고 DB에 반영된다.")
+	void uploadProfileImage_Success() {
+		// given
+		Long userId = 1L;
+		User user = User.createForSignup("테스터", "test@test.com", "pw", "01012341234");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		MockMultipartFile file = new MockMultipartFile(
+			"file", "profile.jpg", "image/jpeg", "dummy-image-data".getBytes()
+		);
+
+		ProfileImage oldImage = ProfileImage.builder().url("old.jpg").isPrimary(true).user(user).build();
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(s3Uploader.upload(any(MultipartFile.class), anyString())).willReturn("https://s3-url.com/new.jpg");
+		given(profileImageRepository.findByUserIdAndIsPrimaryTrue(userId)).willReturn(Optional.of(oldImage));
+
+		// when
+		ProfileImageRes result = userService.uploadProfileImage(userId, file);
+
+		// then
+		assertThat(result.imageUrl()).isEqualTo("https://s3-url.com/new.jpg");
+		assertThat(oldImage.isPrimary()).isFalse();
+
+		verify(s3Uploader).upload(any(MultipartFile.class), eq("users/" + userId + "/profile"));
+		verify(profileImageRepository).save(any(ProfileImage.class));
+	}
+
+	@Test
+	@DisplayName("실패: 빈 파일(Empty)을 업로드하면 예외 발생")
+	void uploadProfileImage_Fail_EmptyFile() {
+		// given
+		Long userId = 1L;
+		MockMultipartFile emptyFile = new MockMultipartFile("file", new byte[0]);
+
+		// when & then
+		assertThatThrownBy(() -> userService.uploadProfileImage(userId, emptyFile))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(GlobalErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("실패: 5MB를 초과하는 이미지는 예외 발생")
+	void uploadProfileImage_Fail_SizeLimit() {
+		// given
+		Long userId = 1L;
+
+		byte[] largeData = new byte[5 * 1024 * 1024 + 1];
+		MockMultipartFile largeFile = new MockMultipartFile(
+			"file", "large.jpg", "image/jpeg", largeData
+		);
+
+		// when & then
+		assertThatThrownBy(() -> userService.uploadProfileImage(userId, largeFile))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(UserErrorCode.PROFILE_IMAGE_TOO_LARGE);
+	}
+
+	@Test
+	@DisplayName("실패: 이미지가 아닌 파일(txt 등)은 예외 발생")
+	void uploadProfileImage_Fail_InvalidType() {
+		// given
+		Long userId = 1L;
+		MockMultipartFile textFile = new MockMultipartFile(
+			"file", "test.txt", "text/plain", "text-data".getBytes()
+		);
+
+		// when & then
+		assertThatThrownBy(() -> userService.uploadProfileImage(userId, textFile))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(UserErrorCode.INVALID_PROFILE_IMAGE_TYPE);
+	}
+
+	@Test
+	@DisplayName("실패: 존재하지 않는 유저는 업로드 불가")
+	void uploadProfileImage_Fail_UserNotFound() {
+		// given
+		Long userId = 99L;
+		MockMultipartFile file = new MockMultipartFile(
+			"file", "profile.jpg", "image/jpeg", "data".getBytes()
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> userService.uploadProfileImage(userId, file))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(UserErrorCode.USER_NOT_FOUND);
 	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
@@ -34,7 +34,6 @@ import com.github.sleeplessspecialist.peaktime.domain.user.repository.ProfileIma
 import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
 import com.github.sleeplessspecialist.peaktime.domain.user.service.UserService;
 import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
-import com.github.sleeplessspecialist.peaktime.global.common.error.GlobalErrorCode;
 import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
 
 @ExtendWith(MockitoExtension.class)
@@ -189,7 +188,7 @@ class UserServiceTest {
 		assertThatThrownBy(() -> userService.uploadProfileImage(userId, emptyFile))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
-			.isEqualTo(GlobalErrorCode.INVALID_REQUEST);
+			.isEqualTo(UserErrorCode.EMPTY_FILE_EXCEPTION);
 	}
 
 	@Test

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
@@ -242,4 +242,30 @@ class UserServiceTest {
 			.extracting("errorCode")
 			.isEqualTo(UserErrorCode.USER_NOT_FOUND);
 	}
+
+	@Test
+	@DisplayName("실패: DB 저장 중 에러 발생 시 업로드된 S3 파일을 삭제해야 한다.")
+	void uploadProfileImage_Fail_DbSaveError() {
+		// given
+		Long userId = 1L;
+		User user = User.createForSignup("테스터", "test@test.com", "pw", "01012341234");
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		MockMultipartFile file = new MockMultipartFile(
+			"file", "profile.jpg", "image/jpeg", "dummy-data".getBytes()
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		String uploadedUrl = "https://s3-url.com/uploaded.jpg";
+		given(s3Uploader.upload(any(MultipartFile.class), anyString())).willReturn(uploadedUrl);
+		given(profileImageRepository.save(any(ProfileImage.class)))
+			.willThrow(new RuntimeException("DB Connection Error"));
+
+		// when & then
+		assertThatThrownBy(() -> userService.uploadProfileImage(userId, file))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("DB Connection Error");
+		
+		verify(s3Uploader).deleteFile(uploadedUrl);
+	}
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #43 

---

## ✨ 작업 내용
사용자가 자신의 프로필 이미지를 업로드하고 변경하는 기능을 구현했습니다.

- [x] 기능 추가
- MultipartFile을 받아 AWS S3에 업로드하고, 반환된 URL을 DB에 저장합니다.
- 파일 용량 제한: 5MB (초과 시 PROFILE_IMAGE_TOO_LARGE 예외) 

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게
현재는 기존 이미지를 삭제하지 않고 isPrimary=false로 남겨두어 히스토리를 관리하도록 구현했습니다. 추후 S3 용량 관리가 필요할지 의견 주시면 감사하겠습니다.