### PR TITLE
[fix] HTTPS 환경에서 OAuth2 redirect URI 불일치 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,7 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
-  forward-headers-strategy: native
+  forward-headers-strategy: framework
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,6 +101,7 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+  forward-headers-strategy: native
 
 logging:
   level:


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- ref #122 

---

## ✨ 작업 내용
Nginx 리버스 프록시(HTTPS) 환경에서 OAuth redirect_uri가 http로 생성되는 문제를 해결하기 위해,
Reverse Proxy 헤더(X-Forwarded-*) 전달 설정을 점검/보강하고 적용 절차 및 검증 방법을 정리했습니다.
- [x] 버그 수정
- [x] 리팩토링

---
## 🧩 배경

운영 환경은 아래와 같은 구조로 구성되어 있다.

Client (HTTPS)  
→ Nginx (443, SSL Termination)  
→ Spring Boot (8080, HTTP)

외부 요청은 HTTPS로 들어오지만,
Spring Boot는 내부 HTTP 요청(8080)을 기준으로 URL을 생성하기 때문에 OAuth 요청 시 다음과 같은 redirect_uri가 생성되었다.

`redirect_uri=http://peaktime-edu.xyz/`

OAuth 콘솔에는 HTTPS 기준 URI가 등록되어 있어 `redirect_uri_mismatch` 에러가 발생하였다.

---

## 🔧 조치 사항

### 1. Nginx Reverse Proxy 헤더 보강

Reverse Proxy 환경에서 원래 요청 정보를 Spring에 전달하도록 Forwarded Header 설정을 보완하였다.

적용 파일:`/etc/nginx/conf.d/peaktime-edu.xyz.conf`


location 블록 최종 설정:

```nginx
location / {
    proxy_pass http://127.0.0.1:8080;

    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

    proxy_set_header X-Forwarded-Proto https;
    proxy_set_header X-Forwarded-Host $host;
    proxy_set_header X-Forwarded-Port $server_port;
}
```
---

## 💬 리뷰어에게
특히 봐줬으면 하는 부분이나 질문이 있다면 작성해주세요.