### PR TITLE
[hotfix]: oauth2 redirect uri 정상작동을 위한 엔드포인트 일치화

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/config/SecurityConfig.java
@@ -80,9 +80,9 @@ public class SecurityConfig {
 			// OAuth2 Login configuration (Kakao)
 			// OAuth2 인증 흐름은 서버에서 처리하고, 로그인 성공 후 JWT를 발급한다.
 			.oauth2Login(oauth2 -> oauth2
-				// 카카오 Redirect URI: /api/v1/oauth2/code/kakao
+				// 카카오 Redirect URI: /api/v2/oauth2/code/kakao
 				.redirectionEndpoint(redirection -> redirection
-					.baseUri("/api/v1/oauth2/code/*")
+					.baseUri("/api/v2/oauth2/code/*")
 				)
 				// 사용자 정보 매핑
 				.userInfoEndpoint(userInfo -> userInfo

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
@@ -48,7 +48,7 @@ public final class SecurityPathPolicy {
 		// OAuth2
 		"/oauth2/**",
 		"/login/oauth2/**",
-		"/api/v1/oauth2/**"
+		"/api/v2/oauth2/**"
 	};
 
 	/**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}  # (시크릿 ON이면 필수)
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/api/v1/oauth2/code/kakao"
+            redirect-uri: "{baseUrl}/api/v2/oauth2/code/kakao"
             scope:
               - profile_nickname
               - account_email
@@ -37,7 +37,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/api/v1/oauth2/code/google"
+            redirect-uri: "{baseUrl}/api/v2/oauth2/code/google"
             scope:
               - email
               - profile


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- ref #122 

---

## ✨ 작업 내용
oauth2 redirect uri 정상작동을 위한 엔드포인트 일치화

- [x] 버그 수정
- [x] 리팩토링

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
---

## 💬 리뷰어에게
Redirect uri 정상 작동을 위한 수정 PR입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OAuth2 인증 엔드포인트를 API v1에서 v2로 업그레이드했습니다.
  * Kakao 및 Google OAuth2 로그인 리다이렉트 URI 경로를 v2 버전으로 업데이트했습니다.
  * 공개 API 경로 설정도 함께 v2로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->