### PR TITLE
[feat] 수강 영상 재생 API 구현

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
@@ -24,4 +24,6 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 	boolean existsByUserIdAndCourseIdIn(Long userId, List<Long> courseIds);
 
 	List<Enrollment> findAllByUserIdAndStatusOrderByCreatedAtDesc(Long userId, EnrollmentStatus status);
+
+	boolean existsByUserIdAndCourseIdAndStatus(Long userId, Long courseId, EnrollmentStatus status);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
@@ -1,6 +1,8 @@
 package com.github.sleeplessspecialist.peaktime.domain.lecture.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LecturePlaybackRes;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.service.LectureService;
 import com.github.sleeplessspecialist.peaktime.global.common.response.ApiResponse;
 
@@ -17,11 +20,12 @@ import lombok.RequiredArgsConstructor;
 /**
  * 강의 영상 관련 API 요청을 처리하는 컨트롤러입니다.
  * <p>
- * 특정 과정(Course) 하위에 영상을 업로드하거나 관리하는 기능을 제공합니다.
+ * 특정 과정(Course) 하위에 영상을 업로드하거나,
+ * 수강 권한이 있는 사용자에게 영상 재생 정보를 제공합니다.
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @RestController
@@ -48,5 +52,19 @@ public class LectureController {
 
 		Long lectureId = lectureService.createLecture(courseId, req);
 		return ApiResponse.created(lectureId);
+	}
+
+	/**
+	 * 강의 영상 재생(스트리밍) 정보를 조회합니다.
+	 * 수강 권한을 확인 후, 30분간 유효한 Presigned URL을 반환합니다.
+	 */
+	@GetMapping("/lectures/{lectureId}/playback")
+	public ApiResponse<LecturePlaybackRes> getPlaybackUrl(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long lectureId
+	) {
+
+		LecturePlaybackRes response = lectureService.getPlaybackInfo(userId, lectureId);
+		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/controller/LectureController.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
@@ -30,7 +29,6 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/courses")
 public class LectureController {
 
 	private final LectureService lectureService;
@@ -45,7 +43,7 @@ public class LectureController {
 	 * @param req      업로드할 영상 파일과 제목 정보 (ModelAttribute 바인딩)
 	 * @return 등록된 강의 영상의 ID
 	 */
-	@PostMapping(value = "/{courseId}/lectures", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(value = "/api/v1/courses/{courseId}/lectures", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ApiResponse<Long> uploadLecture(
 		@PathVariable Long courseId,
 		@Valid @ModelAttribute LectureCreateReq req) {
@@ -58,7 +56,7 @@ public class LectureController {
 	 * 강의 영상 재생(스트리밍) 정보를 조회합니다.
 	 * 수강 권한을 확인 후, 30분간 유효한 Presigned URL을 반환합니다.
 	 */
-	@GetMapping("/lectures/{lectureId}/playback")
+	@GetMapping("/api/v1/lectures/{lectureId}/playback")
 	public ApiResponse<LecturePlaybackRes> getPlaybackUrl(
 		@AuthenticationPrincipal Long userId,
 		@PathVariable Long lectureId

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LecturePlaybackRes.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/dto/LecturePlaybackRes.java
@@ -1,0 +1,21 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture.dto;
+
+import lombok.Builder;
+
+/**
+ * 강의 영상 재생을 위한 응답 DTO입니다.
+ * <p>
+ * 클라이언트에게 강의 제목과 보안 처리된 스트리밍 URL(Presigned URL)을 전달합니다.
+ * </p>
+ *
+ * @author 기섭
+ * @version 1.0
+ * @since 2026. 2. 6.
+ */
+@Builder
+public record LecturePlaybackRes(
+	Long lectureId,
+	String title,
+	String videoUrl
+) {
+}

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/exception/LectureErrorCode.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 23.
  */
 @Getter
@@ -22,7 +22,9 @@ import lombok.RequiredArgsConstructor;
 public enum LectureErrorCode implements ErrorCode {
 
 	INVALID_FILE_EXTENSION("L001", "지원하지 않는 파일 형식입니다.", HttpStatus.BAD_REQUEST),
-	INVALID_FILE_NAME("L002", "파일 이름이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+	INVALID_FILE_NAME("L002", "파일 이름이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+	LECTURE_NOT_FOUND("L003", "존재하지 않는 강의 영상입니다.", HttpStatus.NOT_FOUND),
+	NOT_ENROLLED_USER("L004", "수강 권한이 없는 사용자입니다.", HttpStatus.FORBIDDEN);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/lecture/service/LectureService.java
@@ -8,7 +8,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
 import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.EnrollmentStatus;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LectureCreateReq;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LecturePlaybackRes;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.exception.LectureErrorCode;
 import com.github.sleeplessspecialist.peaktime.domain.lecture.repository.LectureRepository;
@@ -24,10 +27,11 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * 전달받은 영상 파일을 S3에 업로드하고, 반환된 URL을 이용해
  * Lecture 엔티티를 생성 및 저장하는 역할을 수행합니다.
+ * 권한이 있는 사용자에게 영상 재생을 위한 Presigned URL을 발급합니다.
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @Slf4j
@@ -37,6 +41,7 @@ public class LectureService {
 
 	private final LectureRepository lectureRepository;
 	private final CourseRepository courseRepository;
+	private final EnrollmentRepository enrollmentRepository; // 권한 체크용 추가
 	private final S3Uploader s3Uploader;
 
 	private static final List<String> ALLOWED_VIDEO_EXTENSIONS = List.of("mp4", "avi", "mov", "wmv", "mkv");
@@ -83,6 +88,39 @@ public class LectureService {
 	}
 
 	/**
+	 * 강의 영상 재생(스트리밍) 정보를 조회합니다.
+	 * <p>
+	 * 1. 강의 존재 여부 확인
+	 * 2. 사용자의 수강 권한 검증
+	 * 3. S3 Presigned URL(30분 유효) 발급
+	 * </p>
+	 */
+	@Transactional(readOnly = true)
+	public LecturePlaybackRes getPlaybackInfo(Long userId, Long lectureId) {
+		Lecture lecture = lectureRepository.findById(lectureId)
+			.orElseThrow(() -> new CustomException(LectureErrorCode.LECTURE_NOT_FOUND));
+
+		Long courseId = lecture.getCourse().getId();
+		boolean isEnrolled = enrollmentRepository.existsByUserIdAndCourseIdAndStatus(
+			userId, courseId, EnrollmentStatus.ENROLLED);
+
+		if (!isEnrolled) {
+			throw new CustomException(LectureErrorCode.NOT_ENROLLED_USER);
+		}
+
+		// 전체 URL에서 파일 키(Key) 추출 (S3 Presigned URL 발급용)
+		String originalUrl = lecture.getVideoUrl();
+		String fileKey = extractFileKeyFromUrl(originalUrl);
+		String presignedUrl = s3Uploader.getPresignedUrl(fileKey);
+
+		return LecturePlaybackRes.builder()
+			.lectureId(lecture.getId())
+			.title(lecture.getTitle())
+			.videoUrl(presignedUrl)
+			.build();
+	}
+
+	/**
 	 * 업로드된 파일의 확장자가 허용된 비디오 형식인지 검증함
 	 */
 	private void validateVideoFileExtension(MultipartFile file) {
@@ -97,5 +135,16 @@ public class LectureService {
 		if (!ALLOWED_VIDEO_EXTENSIONS.contains(extension)) {
 			throw new CustomException(LectureErrorCode.INVALID_FILE_EXTENSION);
 		}
+	}
+
+	/**
+	 * 저장된 전체 URL에서 S3 파일 키(경로)를 추출
+	 */
+	private String extractFileKeyFromUrl(String url) {
+		String splitStr = ".com/";
+		if (url.contains(splitStr)) {
+			return url.substring(url.indexOf(splitStr) + splitStr.length());
+		}
+		return url;
 	}
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/infra/s3/S3Uploader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  *
  * @author 기섭
- * @version 1.0
+ * @version 1.1
  * @since 2026. 1. 22.
  */
 @Slf4j
@@ -47,6 +48,7 @@ public class S3Uploader {
 	 * @return 업로드된 파일의 전체 URL
 	 */
 	public String upload(MultipartFile file, String dirName) {
+		
 		if (file.isEmpty()) {
 			throw new CustomException(GlobalErrorCode.INVALID_REQUEST);
 		}
@@ -74,7 +76,21 @@ public class S3Uploader {
 	 * S3에 저장된 파일의 전체 URL을 가져옵니다.
 	 */
 	private String getFileUrl(String fileName) {
+
 		return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
+	}
+
+	/**
+	 * Presigned URL(서명된 임시 접근 URL)을 발급합니다.
+	 * 보안이 필요한 영상 스트리밍 등을 위해 사용되며, 30분의 유효기간을 가집니다.
+	 *
+	 * @param filename S3 내부 파일 경로 (Key) (예: video/uuid_file.mp4)
+	 * @return 유효기간이 포함된 전체 URL
+	 */
+	public String getPresignedUrl(String filename) {
+
+		return s3Template.createSignedGetURL(bucket, filename, Duration.ofMinutes(30))
+			.toString();
 	}
 
 	/**
@@ -84,6 +100,7 @@ public class S3Uploader {
 	 * @param fileUrl 삭제할 파일의 전체 URL (예: https://bucket.s3.../video/uuid_file.mp4)
 	 */
 	public void deleteFile(String fileUrl) {
+
 		try {
 			String splitStr = ".com/";
 			String fileName = fileUrl.substring(fileUrl.lastIndexOf(splitStr) + splitStr.length());

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/lecture/LectureServiceTest.java
@@ -1,0 +1,143 @@
+package com.github.sleeplessspecialist.peaktime.domain.lecture;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.course.repository.CourseRepository;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.EnrollmentStatus;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.dto.LecturePlaybackRes;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.entity.Lecture;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.exception.LectureErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.repository.LectureRepository;
+import com.github.sleeplessspecialist.peaktime.domain.lecture.service.LectureService;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import com.github.sleeplessspecialist.peaktime.global.infra.s3.S3Uploader;
+
+/**
+ * LectureService 단위 테스트
+ *
+ * @author 기섭
+ * @since 2026. 2. 23.
+ */
+@ExtendWith(MockitoExtension.class)
+class LectureServiceTest {
+
+	@Mock
+	private LectureRepository lectureRepository;
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Mock
+	private EnrollmentRepository enrollmentRepository;
+
+	@Mock
+	private S3Uploader s3Uploader;
+
+	@InjectMocks
+	private LectureService lectureService;
+
+	@Test
+	@DisplayName("ENROLLED 사용자는 200 + presigned URL을 반환한다 (S3Uploader mock)")
+	void playback_enrolled_user_returns_presigned_url() {
+		// given
+		Long userId = 1L;
+		Long lectureId = 10L;
+		Long courseId = 100L;
+
+		Lecture lecture = mock(Lecture.class);
+		Course course = mock(Course.class);
+
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+		when(lecture.getCourse()).thenReturn(course);
+		when(course.getId()).thenReturn(courseId);
+
+		when(enrollmentRepository.existsByUserIdAndCourseIdAndStatus(
+			userId, courseId, EnrollmentStatus.ENROLLED
+		)).thenReturn(true);
+		
+		when(lecture.getVideoUrl()).thenReturn("https://bucket.s3.ap-northeast-2.amazonaws.com/video/uuid_test.mp4");
+		when(s3Uploader.getPresignedUrl("video/uuid_test.mp4")).thenReturn("https://signed-url");
+
+		when(lecture.getId()).thenReturn(lectureId);
+		when(lecture.getTitle()).thenReturn("테스트 강의");
+
+		// when
+		LecturePlaybackRes res = lectureService.getPlaybackInfo(userId, lectureId);
+
+		// then
+		assertThat(res).isNotNull();
+		assertThat(res.lectureId()).isEqualTo(lectureId);
+		assertThat(res.title()).isEqualTo("테스트 강의");
+		assertThat(res.videoUrl()).isEqualTo("https://signed-url");
+
+		verify(lectureRepository).findById(lectureId);
+		verify(enrollmentRepository).existsByUserIdAndCourseIdAndStatus(userId, courseId, EnrollmentStatus.ENROLLED);
+		verify(s3Uploader).getPresignedUrl("video/uuid_test.mp4");
+	}
+
+	@Test
+	@DisplayName("미수강 사용자는 403(L004: NOT_ENROLLED_USER)을 반환한다")
+	void playback_not_enrolled_user_throws_forbidden() {
+		// given
+		Long userId = 1L;
+		Long lectureId = 10L;
+		Long courseId = 100L;
+
+		Lecture lecture = mock(Lecture.class);
+		Course course = mock(Course.class);
+
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+		when(lecture.getCourse()).thenReturn(course);
+		when(course.getId()).thenReturn(courseId);
+
+		when(enrollmentRepository.existsByUserIdAndCourseIdAndStatus(
+			userId, courseId, EnrollmentStatus.ENROLLED
+		)).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> lectureService.getPlaybackInfo(userId, lectureId))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> {
+				CustomException ce = (CustomException)ex;
+				assertThat(ce.getErrorCode()).isEqualTo(LectureErrorCode.NOT_ENROLLED_USER);
+				assertThat(ce.getErrorCode().getCode()).isEqualTo("L004");
+			});
+
+		verify(s3Uploader, never()).getPresignedUrl(any());
+	}
+
+	@Test
+	@DisplayName("강의 미존재는 404(L003: LECTURE_NOT_FOUND)을 반환한다")
+	void playback_lecture_not_found_throws_not_found() {
+		// given
+		Long userId = 1L;
+		Long lectureId = 999L;
+
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> lectureService.getPlaybackInfo(userId, lectureId))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> {
+				CustomException ce = (CustomException)ex;
+				assertThat(ce.getErrorCode()).isEqualTo(LectureErrorCode.LECTURE_NOT_FOUND);
+				assertThat(ce.getErrorCode().getCode()).isEqualTo("L003");
+			});
+
+		verify(enrollmentRepository, never()).existsByUserIdAndCourseIdAndStatus(any(), any(), any());
+		verify(s3Uploader, never()).getPresignedUrl(any());
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #64 
- ref #155 

---

## ✨ 작업 내용
수강 신청이 완료된 사용자만 강의 영상을 재생할 수 있도록 강의 재생(스트리밍) API를 구현하고
S3 Presigned GET URL을 활용하여 보안 접근을 적용했습니다.

- [x] 기능 추가
- GET /api/v1/courses/lectures/{lectureId}/playback API 추가
- 강의 존재 여부 검증 (LECTURE_NOT_FOUND) 
- 수강 권한 검증 (EnrollmentStatus = ENROLLED)
- 미수강 사용자 접근 시 403 처리
- S3 Presigned GET URL (30분 유효) 발급
- LecturePlaybackRes 응답 DTO 추가
- S3 파일 업로드 시 확장자 검증 로직 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게
Presigned URL 발급 구조가 향후 CloudFront Signed URL로 확장 가능한 구조인지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 인증된 사용자가 강의 재생 정보를 조회할 수 있는 재생 API 추가
  * 임시(프리사인) URL 기반의 보안 스트리밍 지원 추가

* **버그 수정 / 접근 제어**
  * 미수강 사용자 접근 시 권한 오류(403) 처리 추가
  * 존재하지 않는 강의 접근 시 적절한 404 오류 처리 추가

* **테스트**
  * 재생 경로의 정상 및 오류 케이스를 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->