### PR TITLE
[feat] N+1 문제 해결 및 fetch join 적용

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/enrollment/repository/EnrollmentRepository.java
@@ -3,6 +3,8 @@ package com.github.sleeplessspecialist.peaktime.domain.enrollment.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
 import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.EnrollmentStatus;
@@ -26,4 +28,18 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 	List<Enrollment> findAllByUserIdAndStatusOrderByCreatedAtDesc(Long userId, EnrollmentStatus status);
 
 	boolean existsByUserIdAndCourseIdAndStatus(Long userId, Long courseId, EnrollmentStatus status);
+
+	@Query("""
+		   select e
+		   from Enrollment e
+		   join fetch e.course c
+		   join fetch c.lecturer
+		   where e.user.id = :userId
+		     and e.status = :status
+		   order by e.createdAt desc
+		""")
+	List<Enrollment> findAllWithCourseAndLecturerByUserIdAndStatus(
+		@Param("userId") Long userId,
+		@Param("status") EnrollmentStatus status
+	);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,13 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.repository;
 
-import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
-import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
 
 /**
  * 리뷰(Review) 엔티티에 대한 영속성 처리를 담당하는 리포지토리입니다.
@@ -19,5 +22,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    Page<Review> findAllByEnrollment_User(User user, Pageable pageable);
+	Page<Review> findAllByEnrollment_User(User user, Pageable pageable);
+
+	@Query(
+		value = """
+			   select r
+			   from Review r
+			   join fetch r.enrollment e
+			   join fetch e.course
+			   where e.user = :user
+			""",
+		countQuery = """
+			   select count(r)
+			   from Review r
+			   where r.enrollment.user = :user
+			"""
+	)
+	Page<Review> findAllByEnrollmentUserWithCourse(
+		@Param("user") User user,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/review/service/ReviewService.java
@@ -1,17 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.review.service;
 
-import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
-import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
-import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.*;
-import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
-import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
-import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
-import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
-import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
-import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,7 +10,25 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewReq;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.GetReviewDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.GetReviewListRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.ReviewListItemRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.UpdateReviewReq;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.UpdateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
+import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 리뷰 생성/변경과 같은 상태 변경 커맨드를 담당하는 서비스입니다.
@@ -39,208 +47,208 @@ import java.util.List;
 @Slf4j
 public class ReviewService {
 
-    private final ReviewRepository reviewRepository;
-    private final EnrollmentRepository enrollmentRepository;
-    private final UserRepository userRepository;
+	private final ReviewRepository reviewRepository;
+	private final EnrollmentRepository enrollmentRepository;
+	private final UserRepository userRepository;
 
-    /**
-     * 리뷰 생성
-     * 1. userId DB 존재 여부 확인
-     * 2. enrollment 로 인가 검증
-     * 3. 해당 course 의 가중치 갱신
-     * 4. review 영속성 저장및 응답 dto 리턴
-     */
-    @Transactional
-    public CreateReviewRes createReview(Long userId, Long enrollmentId, CreateReviewReq req) {
+	/**
+	 * 리뷰 생성
+	 * 1. userId DB 존재 여부 확인
+	 * 2. enrollment 로 인가 검증
+	 * 3. 해당 course 의 가중치 갱신
+	 * 4. review 영속성 저장및 응답 dto 리턴
+	 */
+	@Transactional
+	public CreateReviewRes createReview(Long userId, Long enrollmentId, CreateReviewReq req) {
 
-        validateUserExists(userId);
+		validateUserExists(userId);
 
-        Enrollment enrollment = getEnrollment(enrollmentId);
+		Enrollment enrollment = getEnrollment(enrollmentId);
 
-        validateEnrollmentOwner(userId, enrollment);
+		validateEnrollmentOwner(userId, enrollment);
 
-        Course course = enrollment.getCourse();
+		Course course = enrollment.getCourse();
 
-        Review review = Review.builder()
-                .enrollment(enrollment)
-                .rating(req.getRating())
-                .content(req.getContent())
-                .build();
+		Review review = Review.builder()
+			.enrollment(enrollment)
+			.rating(req.getRating())
+			.content(req.getContent())
+			.build();
 
-        Review saved;
-        try {
-            saved = reviewRepository.save(review);
-        } catch (DataIntegrityViolationException e) {
-            log.debug("이미 review 가 존재 합니다. userId={}, enrollmentId={}", userId, enrollmentId);
-            throw new CustomException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
-        }
+		Review saved;
+		try {
+			saved = reviewRepository.save(review);
+		} catch (DataIntegrityViolationException e) {
+			log.debug("이미 review 가 존재 합니다. userId={}, enrollmentId={}", userId, enrollmentId);
+			throw new CustomException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+		}
 
-        course.updateRatingWeight(saved.getRating());
+		course.updateRatingWeight(saved.getRating());
 
-        return CreateReviewRes.builder()
-                .id(saved.getId())
-                .enrollmentId(enrollment.getId())
-                .courseId(course.getId())
-                .userId(userId)
-                .rating(saved.getRating())
-                .content(saved.getContent())
-                .createdAt(saved.getCreatedAt())
-                .updatedAt(saved.getUpdatedAt())
-                .build();
-    }
+		return CreateReviewRes.builder()
+			.id(saved.getId())
+			.enrollmentId(enrollment.getId())
+			.courseId(course.getId())
+			.userId(userId)
+			.rating(saved.getRating())
+			.content(saved.getContent())
+			.createdAt(saved.getCreatedAt())
+			.updatedAt(saved.getUpdatedAt())
+			.build();
+	}
 
-    /**
-     * 리뷰 상세 조회
-     * 1. userId DB 존재 여부 확인
-     * 2. reviewId DB 존재 여부 확인
-     * 3. review 로 인가 검증
-     * 4. 응답 dto 리턴
-     */
-    @Transactional(readOnly = true)
-    public GetReviewDetailRes getReviewDetail(Long userId, Long reviewId) {
+	/**
+	 * 리뷰 상세 조회
+	 * 1. userId DB 존재 여부 확인
+	 * 2. reviewId DB 존재 여부 확인
+	 * 3. review 로 인가 검증
+	 * 4. 응답 dto 리턴
+	 */
+	@Transactional(readOnly = true)
+	public GetReviewDetailRes getReviewDetail(Long userId, Long reviewId) {
 
-        validateUserExists(userId);
+		validateUserExists(userId);
 
-        Review review = getReview(reviewId);
+		Review review = getReview(reviewId);
 
-        validateReviewOwner(userId, review);
+		validateReviewOwner(userId, review);
 
-        return GetReviewDetailRes.builder()
-                .reviewId(review.getId())
-                .userId(userId)
-                .enrollmentId(review.getEnrollment().getId())
-                .courseId(review.getEnrollment().getCourse().getId())
-                .rating(review.getRating())
-                .content(review.getContent())
-                .createdAt(review.getCreatedAt())
-                .updatedAt(review.getUpdatedAt())
-                .build();
-    }
+		return GetReviewDetailRes.builder()
+			.reviewId(review.getId())
+			.userId(userId)
+			.enrollmentId(review.getEnrollment().getId())
+			.courseId(review.getEnrollment().getCourse().getId())
+			.rating(review.getRating())
+			.content(review.getContent())
+			.createdAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
+			.build();
+	}
 
-    /**
-     * 리뷰 목록 조회 (나의)
-     * 1. userId DB 존재 여부 확인
-     * 2. Pageable 객체 변환
-     * 3. 쿼리메서드 호출후 응답 dto 로 리턴
-     */
-    @Transactional(readOnly = true)
-    public GetReviewListRes getMyReviews(Long userId, int page, int size) {
+	/**
+	 * 리뷰 목록 조회 (나의)
+	 * 1. userId DB 존재 여부 확인
+	 * 2. Pageable 객체 변환
+	 * 3. 쿼리메서드 호출후 응답 dto 로 리턴
+	 */
+	@Transactional(readOnly = true)
+	public GetReviewListRes getMyReviews(Long userId, int page, int size) {
 
-        User user = getUser(userId);
+		User user = getUser(userId);
 
-        Pageable pageable = PageRequest.of(
-                page - 1,
-                size,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
+		Pageable pageable = PageRequest.of(
+			page - 1,
+			size,
+			Sort.by(Sort.Direction.DESC, "createdAt")
+		);
 
-        Page<Review> reviewPage = reviewRepository.findAllByEnrollment_User(user, pageable);
+		Page<Review> reviewPage = reviewRepository.findAllByEnrollmentUserWithCourse(user, pageable);
 
-        List<ReviewListItemRes> items = reviewPage.getContent().stream()
-                .map(ReviewListItemRes::from)
-                .toList();
+		List<ReviewListItemRes> items = reviewPage.getContent().stream()
+			.map(ReviewListItemRes::from)
+			.toList();
 
-        return GetReviewListRes.builder()
-                .reviews(items)
-                .page(reviewPage.getNumber())
-                .size(reviewPage.getSize())
-                .totalElements(reviewPage.getTotalElements())
-                .totalPages(reviewPage.getTotalPages())
-                .hasNext(reviewPage.hasNext())
-                .build();
-    }
+		return GetReviewListRes.builder()
+			.reviews(items)
+			.page(reviewPage.getNumber())
+			.size(reviewPage.getSize())
+			.totalElements(reviewPage.getTotalElements())
+			.totalPages(reviewPage.getTotalPages())
+			.hasNext(reviewPage.hasNext())
+			.build();
+	}
 
-    /**
-     * 리뷰 갱신
-     * 1. userId DB 존재 여부 확인
-     * 2. reviewId DB 존재 여부 확인
-     * 3. review 로 인가 검증
-     * 4. review update
-     * 5. 응답 dto 리턴
-     */
-    @Transactional
-    public UpdateReviewRes updateReview(Long userId, Long reviewId, UpdateReviewReq req) {
+	/**
+	 * 리뷰 갱신
+	 * 1. userId DB 존재 여부 확인
+	 * 2. reviewId DB 존재 여부 확인
+	 * 3. review 로 인가 검증
+	 * 4. review update
+	 * 5. 응답 dto 리턴
+	 */
+	@Transactional
+	public UpdateReviewRes updateReview(Long userId, Long reviewId, UpdateReviewReq req) {
 
-        validateUserExists(userId);
+		validateUserExists(userId);
 
-        Review review = getReview(reviewId);
+		Review review = getReview(reviewId);
 
-        validateReviewOwner(userId, review);
+		validateReviewOwner(userId, review);
 
-        review.update(req.getRating(), req.getContent());
+		review.update(req.getRating(), req.getContent());
 
-        return UpdateReviewRes.builder()
-                .reviewId(review.getId())
-                .userId(userId)
-                .enrollmentId(review.getEnrollment().getId())
-                .courseId(review.getEnrollment().getCourse().getId())
-                .rating(review.getRating())
-                .content(review.getContent())
-                .createdAt(review.getCreatedAt())
-                .updatedAt(review.getUpdatedAt())
-                .build();
-    }
+		return UpdateReviewRes.builder()
+			.reviewId(review.getId())
+			.userId(userId)
+			.enrollmentId(review.getEnrollment().getId())
+			.courseId(review.getEnrollment().getCourse().getId())
+			.rating(review.getRating())
+			.content(review.getContent())
+			.createdAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
+			.build();
+	}
 
-    /**
-     * 리뷰 삭제
-     * 1. userId DB 존재 여부 확인
-     * 2. reviewId DB 존재 여부 확인
-     * 3. review 로 인가 검증
-     * 4. review 삭제
-     */
-    @Transactional
-    public void deleteReview(Long userId, Long reviewId) {
+	/**
+	 * 리뷰 삭제
+	 * 1. userId DB 존재 여부 확인
+	 * 2. reviewId DB 존재 여부 확인
+	 * 3. review 로 인가 검증
+	 * 4. review 삭제
+	 */
+	@Transactional
+	public void deleteReview(Long userId, Long reviewId) {
 
-        validateUserExists(userId);
+		validateUserExists(userId);
 
-        Review review = getReview(reviewId);
+		Review review = getReview(reviewId);
 
-        validateReviewOwner(userId, review);
+		validateReviewOwner(userId, review);
 
-        reviewRepository.delete(review);
-    }
+		reviewRepository.delete(review);
+	}
 
-    private User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ReviewErrorCode.USER_NOT_FOUND));
-    }
+	private User getUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ReviewErrorCode.USER_NOT_FOUND));
+	}
 
-    private Review getReview(Long reviewId) {
-        return reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new CustomException(ReviewErrorCode.REVIEW_NOT_FOUND));
-    }
+	private Review getReview(Long reviewId) {
+		return reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new CustomException(ReviewErrorCode.REVIEW_NOT_FOUND));
+	}
 
-    private void validateUserExists(Long userId) {
-        if (!userRepository.existsById(userId)) {
-            log.warn("리뷰 생성 실패 - 존재하지 않는 사용자. userId={}", userId);
-            throw new CustomException(ReviewErrorCode.USER_NOT_FOUND);
-        }
-    }
+	private void validateUserExists(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			log.warn("리뷰 생성 실패 - 존재하지 않는 사용자. userId={}", userId);
+			throw new CustomException(ReviewErrorCode.USER_NOT_FOUND);
+		}
+	}
 
-    private void validateEnrollmentOwner(Long userId, Enrollment enrollment) {
-        Long ownerId = enrollment.getUser().getId();
-        if (!ownerId.equals(userId)) {
-            log.warn(
-                    "리뷰 생성 실패 - 권한 없음. userId={}, enrollmentId={}, ownerId={}",
-                    userId,
-                    enrollment.getId(),
-                    ownerId
-            );
-            throw new CustomException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-        }
-    }
+	private void validateEnrollmentOwner(Long userId, Enrollment enrollment) {
+		Long ownerId = enrollment.getUser().getId();
+		if (!ownerId.equals(userId)) {
+			log.warn(
+				"리뷰 생성 실패 - 권한 없음. userId={}, enrollmentId={}, ownerId={}",
+				userId,
+				enrollment.getId(),
+				ownerId
+			);
+			throw new CustomException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
 
-    private void validateReviewOwner(Long userId, Review review) {
-        Long ownerId = review.getEnrollment().getUser().getId();
-        if (!ownerId.equals(userId)) {
-            log.warn("리뷰 조회 실패 - 권한 없음. userId={}, reviewId={}, ownerId={}", userId, review.getId(), ownerId);
-            throw new CustomException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-        }
-    }
+	private void validateReviewOwner(Long userId, Review review) {
+		Long ownerId = review.getEnrollment().getUser().getId();
+		if (!ownerId.equals(userId)) {
+			log.warn("리뷰 조회 실패 - 권한 없음. userId={}, reviewId={}, ownerId={}", userId, review.getId(), ownerId);
+			throw new CustomException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
 
-    private Enrollment getEnrollment(Long enrollmentId) {
-        return enrollmentRepository.findById(enrollmentId)
-                .orElseThrow(() -> new CustomException(ReviewErrorCode.ENROLLMENT_NOT_FOUND));
-    }
+	private Enrollment getEnrollment(Long enrollmentId) {
+		return enrollmentRepository.findById(enrollmentId)
+			.orElseThrow(() -> new CustomException(ReviewErrorCode.ENROLLMENT_NOT_FOUND));
+	}
 
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/user/service/UserService.java
@@ -76,8 +76,8 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public List<MyCourseRes> getMyCourses(Long userId) {
 
-		List<Enrollment> enrollments = enrollmentRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
-			userId, EnrollmentStatus.ENROLLED);
+		List<Enrollment> enrollments =
+			enrollmentRepository.findAllWithCourseAndLecturerByUserIdAndStatus(userId, EnrollmentStatus.ENROLLED);
 
 		return enrollments.stream()
 			.map(enrollment -> MyCourseRes.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 100
 
   data:
     redis:

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/review/ReviewServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/review/ReviewServiceTest.java
@@ -1,16 +1,13 @@
 package com.github.sleeplessspecialist.peaktime.domain.review;
 
-import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
-import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
-import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
-import com.github.sleeplessspecialist.peaktime.domain.review.dto.*;
-import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
-import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
-import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
-import com.github.sleeplessspecialist.peaktime.domain.review.service.ReviewService;
-import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
-import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
-import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,14 +21,23 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.*;
+import com.github.sleeplessspecialist.peaktime.domain.course.entity.Course;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.entity.Enrollment;
+import com.github.sleeplessspecialist.peaktime.domain.enrollment.repository.EnrollmentRepository;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewReq;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.CreateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.GetReviewDetailRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.GetReviewListRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.ReviewListItemRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.UpdateReviewReq;
+import com.github.sleeplessspecialist.peaktime.domain.review.dto.UpdateReviewRes;
+import com.github.sleeplessspecialist.peaktime.domain.review.entity.Review;
+import com.github.sleeplessspecialist.peaktime.domain.review.exception.ReviewErrorCode;
+import com.github.sleeplessspecialist.peaktime.domain.review.repository.ReviewRepository;
+import com.github.sleeplessspecialist.peaktime.domain.review.service.ReviewService;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+import com.github.sleeplessspecialist.peaktime.global.common.error.CustomException;
 
 /**
  * ReviewService 단위 테스트
@@ -47,579 +53,581 @@ import static org.mockito.BDDMockito.*;
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
 
-    @InjectMocks
-    private ReviewService reviewService;
-
-    @Mock
-    private ReviewRepository reviewRepository;
-
-    @Mock
-    private EnrollmentRepository enrollmentRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @Test
-    @DisplayName("리뷰 생성 성공 시: 리뷰가 저장되고 강의 평점 및 리뷰 수가 갱신된다")
-    void createReview_Success() {
-        // given
-        Long userId = 1L;
-        Long enrollmentId = 10L;
-        int rating = 5;
-        String content = "Great course";
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
-
-        CreateReviewReq req = new CreateReviewReq(rating, content);
-
-        LocalDateTime now = LocalDateTime.now();
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
-        given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> {
-            Review saved = invocation.getArgument(0);
-            ReflectionTestUtils.setField(saved, "id", 999L);
-            ReflectionTestUtils.setField(saved, "createdAt", now);
-            ReflectionTestUtils.setField(saved, "updatedAt", now);
-            return saved;
-        });
-
-        // when
-        CreateReviewRes result = reviewService.createReview(userId, enrollmentId, req);
-
-        // then
-        assertThat(result.getId()).isEqualTo(999L);
-        assertThat(result.getCourseId()).isEqualTo(100L);
-        assertThat(result.getUserId()).isEqualTo(userId);
-        assertThat(result.getRating()).isEqualTo(rating);
-        assertThat(result.getContent()).isEqualTo(content);
-        assertThat(result.getCreatedAt()).isEqualTo(now);
-        assertThat(result.getUpdatedAt()).isEqualTo(now);
-
-        assertThat(course.getReviewCount()).isEqualTo(1);
-        assertThat(course.getRatingAvg()).isEqualTo(5.0);
-
-        verify(userRepository).existsById(userId);
-        verify(enrollmentRepository).findById(enrollmentId);
-        verify(reviewRepository).save(any(Review.class));
-    }
-
-    @Test
-    @DisplayName("리뷰 생성 실패: 존재하지 않는 사용자일 경우 예외가 발생한다")
-    void createReview_Fail_UserNotFound() {
-        // given
-        Long userId = 1L;
-        Long enrollmentId = 10L;
-        CreateReviewReq req = new CreateReviewReq(3, "ok");
-
-        given(userRepository.existsById(userId)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
-
-        verify(userRepository).existsById(userId);
-        verifyNoInteractions(enrollmentRepository, reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 생성 실패: 수강 이력이 존재하지 않을 경우 예외가 발생한다")
-    void createReview_Fail_EnrollmentNotFound() {
-        // given
-        Long userId = 1L;
-        Long enrollmentId = 10L;
-        CreateReviewReq req = new CreateReviewReq(3, "ok");
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.ENROLLMENT_NOT_FOUND);
-
-        verify(userRepository).existsById(userId);
-        verify(enrollmentRepository).findById(enrollmentId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 생성 실패: 수강 이력의 소유자가 아닌 경우 접근 권한 예외가 발생한다")
-    void createReview_Fail_Unauthorized() {
-        // given
-        Long userId = 1L;
-        Long enrollmentId = 10L;
-        CreateReviewReq req = new CreateReviewReq(4, "good");
-
-        User owner = createUser(2L, "owner@test.com");
-        User lecturer = createUser(3L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(enrollmentId, course, owner);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-
-        verify(userRepository).existsById(userId);
-        verify(enrollmentRepository).findById(enrollmentId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 생성 실패: 이미 리뷰가 존재할 경우 중복 리뷰 예외가 발생한다")
-    void createReview_Fail_ReviewAlreadyExists() {
-        // given
-        Long userId = 1L;
-        Long enrollmentId = 10L;
-        CreateReviewReq req = new CreateReviewReq(2, "bad");
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
-        given(reviewRepository.save(any(Review.class)))
-                .willThrow(new DataIntegrityViolationException("dup"));
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
-
-        assertThat(course.getReviewCount()).isEqualTo(0);
-        assertThat(course.getRatingAvg()).isEqualTo(0.0);
-
-        verify(userRepository).existsById(userId);
-        verify(enrollmentRepository).findById(enrollmentId);
-        verify(reviewRepository).save(any(Review.class));
-    }
-
-    @Test
-    @DisplayName("리뷰 상세 조회 성공: 본인 리뷰일 경우 상세 정보를 반환한다")
-    void getReviewDetail_Success() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-        Long enrollmentId = 10L;
-        Long courseId = 100L;
-        int rating = 4;
-        String content = "good";
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(courseId, lecturer);
-        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, rating, content, now, now);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when
-        GetReviewDetailRes result = reviewService.getReviewDetail(userId, reviewId);
-
-        // then
-        assertThat(result.getReviewId()).isEqualTo(reviewId);
-        assertThat(result.getUserId()).isEqualTo(userId);
-        assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
-        assertThat(result.getCourseId()).isEqualTo(courseId);
-        assertThat(result.getRating()).isEqualTo(rating);
-        assertThat(result.getContent()).isEqualTo(content);
-        assertThat(result.getCreatedAt()).isEqualTo(now);
-        assertThat(result.getUpdatedAt()).isEqualTo(now);
-
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 상세 조회 실패: 사용자 미존재 시 예외가 발생한다")
-    void getReviewDetail_Fail_UserNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        given(userRepository.existsById(userId)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 상세 조회 실패: 리뷰 미존재 시 예외가 발생한다")
-    void getReviewDetail_Fail_ReviewNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 상세 조회 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
-    void getReviewDetail_Fail_Unauthorized() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        User owner = createUser(2L, "owner@test.com");
-        User lecturer = createUser(3L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(10L, course, owner);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 목록 조회 성공: 사용자 리뷰 목록과 페이지 정보를 반환한다")
-    void getMyReviews_Success() {
-        // given
-        Long userId = 1L;
-        int page = 1;
-        int size = 2;
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-
-        Enrollment enrollment1 = createEnrollment(10L, course, student);
-        Enrollment enrollment2 = createEnrollment(11L, course, student);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review1 = createReview(1L, enrollment1, 5, "great", now, now);
-        Review review2 = createReview(2L, enrollment2, 3, "ok", now.minusDays(1), now.minusDays(1));
-
-        Pageable pageable = PageRequest.of(page - 1, size);
-        Page<Review> reviewPage = new PageImpl<>(List.of(review1, review2), pageable, 5);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(student));
-        given(reviewRepository.findAllByEnrollment_User(eq(student), any(Pageable.class))).willReturn(reviewPage);
-
-        // when
-        GetReviewListRes result = reviewService.getMyReviews(userId, page, size);
-
-        // then
-        assertThat(result.getPage()).isEqualTo(0);
-        assertThat(result.getSize()).isEqualTo(size);
-        assertThat(result.getTotalElements()).isEqualTo(5);
-        assertThat(result.getTotalPages()).isEqualTo(3);
-        assertThat(result.isHasNext()).isTrue();
-        assertThat(result.getReviews()).hasSize(2);
-
-        ReviewListItemRes item1 = result.getReviews().get(0);
-        assertThat(item1.getReviewId()).isEqualTo(1L);
-        assertThat(item1.getEnrollmentId()).isEqualTo(10L);
-        assertThat(item1.getCourseId()).isEqualTo(100L);
-        assertThat(item1.getRating()).isEqualTo(5);
-        assertThat(item1.getContent()).isEqualTo("great");
-        assertThat(item1.getCreatedAt()).isEqualTo(now);
-
-        ReviewListItemRes item2 = result.getReviews().get(1);
-        assertThat(item2.getReviewId()).isEqualTo(2L);
-        assertThat(item2.getEnrollmentId()).isEqualTo(11L);
-        assertThat(item2.getCourseId()).isEqualTo(100L);
-        assertThat(item2.getRating()).isEqualTo(3);
-        assertThat(item2.getContent()).isEqualTo("ok");
-        assertThat(item2.getCreatedAt()).isEqualTo(now.minusDays(1));
-
-        verify(userRepository).findById(userId);
-        verify(reviewRepository).findAllByEnrollment_User(eq(student), any(Pageable.class));
-    }
-
-    @Test
-    @DisplayName("리뷰 목록 조회 실패: 사용자 미존재 시 예외가 발생한다")
-    void getMyReviews_Fail_UserNotFound() {
-        // given
-        Long userId = 1L;
-
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.getMyReviews(userId, 1, 10))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
-        verify(userRepository).findById(userId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 수정 성공: 본인 리뷰일 경우 평점과 내용을 갱신한다")
-    void updateReview_Success() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-        Long enrollmentId = 10L;
-        Long courseId = 100L;
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(courseId, lecturer);
-        Enrollment enrollment = createEnrollment(enrollmentId, course, student);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, 2, "old", now.minusDays(1), now.minusDays(1));
-
-        UpdateReviewReq req = new UpdateReviewReq(5, "new");
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when
-        UpdateReviewRes result = reviewService.updateReview(userId, reviewId, req);
-
-        // then
-        assertThat(result.getReviewId()).isEqualTo(reviewId);
-        assertThat(result.getUserId()).isEqualTo(userId);
-        assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
-        assertThat(result.getCourseId()).isEqualTo(courseId);
-        assertThat(result.getRating()).isEqualTo(5);
-        assertThat(result.getContent()).isEqualTo("new");
-        assertThat(result.getCreatedAt()).isEqualTo(now.minusDays(1));
-        assertThat(result.getUpdatedAt()).isEqualTo(now.minusDays(1));
-        assertThat(review.getRating()).isEqualTo(5);
-        assertThat(review.getContent()).isEqualTo("new");
-
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 수정 실패: 사용자 미존재 시 예외가 발생한다")
-    void updateReview_Fail_UserNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
-
-        given(userRepository.existsById(userId)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 수정 실패: 리뷰 미존재 시 예외가 발생한다")
-    void updateReview_Fail_ReviewNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 수정 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
-    void updateReview_Fail_Unauthorized() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-        UpdateReviewReq req = new UpdateReviewReq(4, "ok");
-
-        User owner = createUser(2L, "owner@test.com");
-        User lecturer = createUser(3L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(10L, course, owner);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, 2, "old", now, now);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제 성공: 본인 리뷰일 경우 삭제가 수행된다")
-    void deleteReview_Success() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        User student = createUser(userId, "student@test.com");
-        User lecturer = createUser(2L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(10L, course, student);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when
-        reviewService.deleteReview(userId, reviewId);
-
-        // then
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-        verify(reviewRepository).delete(review);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제 실패: 사용자 미존재 시 예외가 발생한다")
-    void deleteReview_Fail_UserNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        given(userRepository.existsById(userId)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verifyNoInteractions(reviewRepository);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제 실패: 리뷰 미존재 시 예외가 발생한다")
-    void deleteReview_Fail_ReviewNotFound() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
-    void deleteReview_Fail_Unauthorized() {
-        // given
-        Long userId = 1L;
-        Long reviewId = 99L;
-
-        User owner = createUser(2L, "owner@test.com");
-        User lecturer = createUser(3L, "lecturer@test.com");
-        Course course = createCourse(100L, lecturer);
-        Enrollment enrollment = createEnrollment(10L, course, owner);
-
-        LocalDateTime now = LocalDateTime.now();
-        Review review = createReview(reviewId, enrollment, 5, "great", now, now);
-
-        given(userRepository.existsById(userId)).willReturn(true);
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
-        verify(userRepository).existsById(userId);
-        verify(reviewRepository).findById(reviewId);
-    }
-
-    private User createUser(Long id, String email) {
-        User user = User.createForSignup("name", email, "pw", "01012345678");
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
-    }
-
-    private Course createCourse(Long id, User lecturer) {
-        Course course = Course.builder()
-                .title("title")
-                .description("desc")
-                .category("BACKEND")
-                .price(BigDecimal.valueOf(10000))
-                .thumbnailUrl("thumb.jpg")
-                .lecturer(lecturer)
-                .build();
-        ReflectionTestUtils.setField(course, "id", id);
-        return course;
-    }
-
-    private Enrollment createEnrollment(Long id, Course course, User user) {
-        Enrollment enrollment = Enrollment.builder()
-                .course(course)
-                .user(user)
-                .build();
-        ReflectionTestUtils.setField(enrollment, "id", id);
-        return enrollment;
-    }
-
-    private Review createReview(Long id, Enrollment enrollment, int rating, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        Review review = Review.builder()
-                .enrollment(enrollment)
-                .rating(rating)
-                .content(content)
-                .build();
-        ReflectionTestUtils.setField(review, "id", id);
-        ReflectionTestUtils.setField(review, "createdAt", createdAt);
-        ReflectionTestUtils.setField(review, "updatedAt", updatedAt);
-        return review;
-    }
+	@InjectMocks
+	private ReviewService reviewService;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private EnrollmentRepository enrollmentRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("리뷰 생성 성공 시: 리뷰가 저장되고 강의 평점 및 리뷰 수가 갱신된다")
+	void createReview_Success() {
+		// given
+		Long userId = 1L;
+		Long enrollmentId = 10L;
+		int rating = 5;
+		String content = "Great course";
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+		CreateReviewReq req = new CreateReviewReq(rating, content);
+
+		LocalDateTime now = LocalDateTime.now();
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
+		given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> {
+			Review saved = invocation.getArgument(0);
+			ReflectionTestUtils.setField(saved, "id", 999L);
+			ReflectionTestUtils.setField(saved, "createdAt", now);
+			ReflectionTestUtils.setField(saved, "updatedAt", now);
+			return saved;
+		});
+
+		// when
+		CreateReviewRes result = reviewService.createReview(userId, enrollmentId, req);
+
+		// then
+		assertThat(result.getId()).isEqualTo(999L);
+		assertThat(result.getCourseId()).isEqualTo(100L);
+		assertThat(result.getUserId()).isEqualTo(userId);
+		assertThat(result.getRating()).isEqualTo(rating);
+		assertThat(result.getContent()).isEqualTo(content);
+		assertThat(result.getCreatedAt()).isEqualTo(now);
+		assertThat(result.getUpdatedAt()).isEqualTo(now);
+
+		assertThat(course.getReviewCount()).isEqualTo(1);
+		assertThat(course.getRatingAvg()).isEqualTo(5.0);
+
+		verify(userRepository).existsById(userId);
+		verify(enrollmentRepository).findById(enrollmentId);
+		verify(reviewRepository).save(any(Review.class));
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패: 존재하지 않는 사용자일 경우 예외가 발생한다")
+	void createReview_Fail_UserNotFound() {
+		// given
+		Long userId = 1L;
+		Long enrollmentId = 10L;
+		CreateReviewReq req = new CreateReviewReq(3, "ok");
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+
+		verify(userRepository).existsById(userId);
+		verifyNoInteractions(enrollmentRepository, reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패: 수강 이력이 존재하지 않을 경우 예외가 발생한다")
+	void createReview_Fail_EnrollmentNotFound() {
+		// given
+		Long userId = 1L;
+		Long enrollmentId = 10L;
+		CreateReviewReq req = new CreateReviewReq(3, "ok");
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.ENROLLMENT_NOT_FOUND);
+
+		verify(userRepository).existsById(userId);
+		verify(enrollmentRepository).findById(enrollmentId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패: 수강 이력의 소유자가 아닌 경우 접근 권한 예외가 발생한다")
+	void createReview_Fail_Unauthorized() {
+		// given
+		Long userId = 1L;
+		Long enrollmentId = 10L;
+		CreateReviewReq req = new CreateReviewReq(4, "good");
+
+		User owner = createUser(2L, "owner@test.com");
+		User lecturer = createUser(3L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(enrollmentId, course, owner);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+
+		verify(userRepository).existsById(userId);
+		verify(enrollmentRepository).findById(enrollmentId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패: 이미 리뷰가 존재할 경우 중복 리뷰 예외가 발생한다")
+	void createReview_Fail_ReviewAlreadyExists() {
+		// given
+		Long userId = 1L;
+		Long enrollmentId = 10L;
+		CreateReviewReq req = new CreateReviewReq(2, "bad");
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
+		given(reviewRepository.save(any(Review.class)))
+			.willThrow(new DataIntegrityViolationException("dup"));
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.createReview(userId, enrollmentId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+
+		assertThat(course.getReviewCount()).isEqualTo(0);
+		assertThat(course.getRatingAvg()).isEqualTo(0.0);
+
+		verify(userRepository).existsById(userId);
+		verify(enrollmentRepository).findById(enrollmentId);
+		verify(reviewRepository).save(any(Review.class));
+	}
+
+	@Test
+	@DisplayName("리뷰 상세 조회 성공: 본인 리뷰일 경우 상세 정보를 반환한다")
+	void getReviewDetail_Success() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+		Long enrollmentId = 10L;
+		Long courseId = 100L;
+		int rating = 4;
+		String content = "good";
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(courseId, lecturer);
+		Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, rating, content, now, now);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when
+		GetReviewDetailRes result = reviewService.getReviewDetail(userId, reviewId);
+
+		// then
+		assertThat(result.getReviewId()).isEqualTo(reviewId);
+		assertThat(result.getUserId()).isEqualTo(userId);
+		assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
+		assertThat(result.getCourseId()).isEqualTo(courseId);
+		assertThat(result.getRating()).isEqualTo(rating);
+		assertThat(result.getContent()).isEqualTo(content);
+		assertThat(result.getCreatedAt()).isEqualTo(now);
+		assertThat(result.getUpdatedAt()).isEqualTo(now);
+
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 상세 조회 실패: 사용자 미존재 시 예외가 발생한다")
+	void getReviewDetail_Fail_UserNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 상세 조회 실패: 리뷰 미존재 시 예외가 발생한다")
+	void getReviewDetail_Fail_ReviewNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 상세 조회 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+	void getReviewDetail_Fail_Unauthorized() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		User owner = createUser(2L, "owner@test.com");
+		User lecturer = createUser(3L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(10L, course, owner);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.getReviewDetail(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 목록 조회 성공: 사용자 리뷰 목록과 페이지 정보를 반환한다")
+	void getMyReviews_Success() {
+		// given
+		Long userId = 1L;
+		int page = 1;
+		int size = 2;
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+
+		Enrollment enrollment1 = createEnrollment(10L, course, student);
+		Enrollment enrollment2 = createEnrollment(11L, course, student);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review1 = createReview(1L, enrollment1, 5, "great", now, now);
+		Review review2 = createReview(2L, enrollment2, 3, "ok", now.minusDays(1), now.minusDays(1));
+
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Review> reviewPage = new PageImpl<>(List.of(review1, review2), pageable, 5);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(student));
+		given(reviewRepository.findAllByEnrollmentUserWithCourse(eq(student), any(Pageable.class))).willReturn(
+			reviewPage);
+
+		// when
+		GetReviewListRes result = reviewService.getMyReviews(userId, page, size);
+
+		// then
+		assertThat(result.getPage()).isEqualTo(0);
+		assertThat(result.getSize()).isEqualTo(size);
+		assertThat(result.getTotalElements()).isEqualTo(5);
+		assertThat(result.getTotalPages()).isEqualTo(3);
+		assertThat(result.isHasNext()).isTrue();
+		assertThat(result.getReviews()).hasSize(2);
+
+		ReviewListItemRes item1 = result.getReviews().get(0);
+		assertThat(item1.getReviewId()).isEqualTo(1L);
+		assertThat(item1.getEnrollmentId()).isEqualTo(10L);
+		assertThat(item1.getCourseId()).isEqualTo(100L);
+		assertThat(item1.getRating()).isEqualTo(5);
+		assertThat(item1.getContent()).isEqualTo("great");
+		assertThat(item1.getCreatedAt()).isEqualTo(now);
+
+		ReviewListItemRes item2 = result.getReviews().get(1);
+		assertThat(item2.getReviewId()).isEqualTo(2L);
+		assertThat(item2.getEnrollmentId()).isEqualTo(11L);
+		assertThat(item2.getCourseId()).isEqualTo(100L);
+		assertThat(item2.getRating()).isEqualTo(3);
+		assertThat(item2.getContent()).isEqualTo("ok");
+		assertThat(item2.getCreatedAt()).isEqualTo(now.minusDays(1));
+
+		verify(userRepository).findById(userId);
+		verify(reviewRepository).findAllByEnrollmentUserWithCourse(eq(student), any(Pageable.class));
+	}
+
+	@Test
+	@DisplayName("리뷰 목록 조회 실패: 사용자 미존재 시 예외가 발생한다")
+	void getMyReviews_Fail_UserNotFound() {
+		// given
+		Long userId = 1L;
+
+		given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.getMyReviews(userId, 1, 10))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+		verify(userRepository).findById(userId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 수정 성공: 본인 리뷰일 경우 평점과 내용을 갱신한다")
+	void updateReview_Success() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+		Long enrollmentId = 10L;
+		Long courseId = 100L;
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(courseId, lecturer);
+		Enrollment enrollment = createEnrollment(enrollmentId, course, student);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, 2, "old", now.minusDays(1), now.minusDays(1));
+
+		UpdateReviewReq req = new UpdateReviewReq(5, "new");
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when
+		UpdateReviewRes result = reviewService.updateReview(userId, reviewId, req);
+
+		// then
+		assertThat(result.getReviewId()).isEqualTo(reviewId);
+		assertThat(result.getUserId()).isEqualTo(userId);
+		assertThat(result.getEnrollmentId()).isEqualTo(enrollmentId);
+		assertThat(result.getCourseId()).isEqualTo(courseId);
+		assertThat(result.getRating()).isEqualTo(5);
+		assertThat(result.getContent()).isEqualTo("new");
+		assertThat(result.getCreatedAt()).isEqualTo(now.minusDays(1));
+		assertThat(result.getUpdatedAt()).isEqualTo(now.minusDays(1));
+		assertThat(review.getRating()).isEqualTo(5);
+		assertThat(review.getContent()).isEqualTo("new");
+
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 수정 실패: 사용자 미존재 시 예외가 발생한다")
+	void updateReview_Fail_UserNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+		UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 수정 실패: 리뷰 미존재 시 예외가 발생한다")
+	void updateReview_Fail_ReviewNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+		UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 수정 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+	void updateReview_Fail_Unauthorized() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+		UpdateReviewReq req = new UpdateReviewReq(4, "ok");
+
+		User owner = createUser(2L, "owner@test.com");
+		User lecturer = createUser(3L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(10L, course, owner);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, 2, "old", now, now);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.updateReview(userId, reviewId, req))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 삭제 성공: 본인 리뷰일 경우 삭제가 수행된다")
+	void deleteReview_Success() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		User student = createUser(userId, "student@test.com");
+		User lecturer = createUser(2L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(10L, course, student);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when
+		reviewService.deleteReview(userId, reviewId);
+
+		// then
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+		verify(reviewRepository).delete(review);
+	}
+
+	@Test
+	@DisplayName("리뷰 삭제 실패: 사용자 미존재 시 예외가 발생한다")
+	void deleteReview_Fail_UserNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.USER_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verifyNoInteractions(reviewRepository);
+	}
+
+	@Test
+	@DisplayName("리뷰 삭제 실패: 리뷰 미존재 시 예외가 발생한다")
+	void deleteReview_Fail_ReviewNotFound() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.REVIEW_NOT_FOUND);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("리뷰 삭제 실패: 본인 리뷰가 아니면 권한 예외가 발생한다")
+	void deleteReview_Fail_Unauthorized() {
+		// given
+		Long userId = 1L;
+		Long reviewId = 99L;
+
+		User owner = createUser(2L, "owner@test.com");
+		User lecturer = createUser(3L, "lecturer@test.com");
+		Course course = createCourse(100L, lecturer);
+		Enrollment enrollment = createEnrollment(10L, course, owner);
+
+		LocalDateTime now = LocalDateTime.now();
+		Review review = createReview(reviewId, enrollment, 5, "great", now, now);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.deleteReview(userId, reviewId))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReviewErrorCode.UNAUTHORIZED_ACCESS);
+		verify(userRepository).existsById(userId);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	private User createUser(Long id, String email) {
+		User user = User.createForSignup("name", email, "pw", "01012345678");
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	private Course createCourse(Long id, User lecturer) {
+		Course course = Course.builder()
+			.title("title")
+			.description("desc")
+			.category("BACKEND")
+			.price(BigDecimal.valueOf(10000))
+			.thumbnailUrl("thumb.jpg")
+			.lecturer(lecturer)
+			.build();
+		ReflectionTestUtils.setField(course, "id", id);
+		return course;
+	}
+
+	private Enrollment createEnrollment(Long id, Course course, User user) {
+		Enrollment enrollment = Enrollment.builder()
+			.course(course)
+			.user(user)
+			.build();
+		ReflectionTestUtils.setField(enrollment, "id", id);
+		return enrollment;
+	}
+
+	private Review createReview(Long id, Enrollment enrollment, int rating, String content, LocalDateTime createdAt,
+		LocalDateTime updatedAt) {
+		Review review = Review.builder()
+			.enrollment(enrollment)
+			.rating(rating)
+			.content(content)
+			.build();
+		ReflectionTestUtils.setField(review, "id", id);
+		ReflectionTestUtils.setField(review, "createdAt", createdAt);
+		ReflectionTestUtils.setField(review, "updatedAt", updatedAt);
+		return review;
+	}
 }

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/user/UserServiceTest.java
@@ -122,7 +122,7 @@ class UserServiceTest {
 			.build();
 		ReflectionTestUtils.setField(enrollment, "createdAt", LocalDateTime.now());
 
-		given(enrollmentRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(userId, EnrollmentStatus.ENROLLED))
+		given(enrollmentRepository.findAllWithCourseAndLecturerByUserIdAndStatus(userId, EnrollmentStatus.ENROLLED))
 			.willReturn(List.of(enrollment));
 
 		// when
@@ -138,7 +138,7 @@ class UserServiceTest {
 	void getMyCourses_Success_Empty() {
 		// given
 		Long userId = 1L;
-		given(enrollmentRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(userId, EnrollmentStatus.ENROLLED))
+		given(enrollmentRepository.findAllWithCourseAndLecturerByUserIdAndStatus(userId, EnrollmentStatus.ENROLLED))
 			.willReturn(Collections.emptyList());
 
 		// when
@@ -265,7 +265,7 @@ class UserServiceTest {
 		assertThatThrownBy(() -> userService.uploadProfileImage(userId, file))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage("DB Connection Error");
-		
+
 		verify(s3Uploader).deleteFile(uploadedUrl);
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #151 

---

## ✨ 작업 내용
확정적으로 N+1이 발생하던 구간을 최소 변경 전략으로 개선했습니다.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
1️⃣ 내 강의 목록 (UserService.getMyCourses)
문제
- Enrollment → Course → Lecturer LAZY 연쇄 접근
- 1 + N + L 형태의 다중 SELECT 발생 가능
조치
- EnrollmentRepository에 fetch join 적용
- Course + Lecturer를 한 번에 조회

2️⃣ 내 리뷰 목록 (ReviewService.getMyReviews)
문제
- Review → Enrollment → Course LAZY 접근
- Page 조회 시 리뷰 수에 비례한 추가 SELECT 발생

조치
- fetch join + countQuery 분리 적용
---

## 📸 스크린샷 (선택)
강조해야할 코드, 보여주어야 할 내용이 있다면 담아주세요.

---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
fetch join + countQuery 전략이 적절한지 확인 부탁드립니다.
default_batch_fetch_size 값(100)이 적절한지도 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 관련 엔티티(수강/강사/강의)를 한 번의 조회로 함께 불러오도록 쿼리 최적화하여 목록 조회 성능 향상.
  * Hibernate 기본 배치 페치 사이즈를 100으로 설정하여 DB 호출 횟수 감소.

* **리팩터**
  * 리뷰·유저 관련 서비스의 데이터 조회 방식을 통합·정리하여 일관성 개선.

* **테스트**
  * 단위 테스트를 Mockito 기반으로 재구성하여 모킹과 가독성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->