### PR TITLE
feat 참여 제한 인원(2명) 동시성 문제 해결

### DIFF
--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/controller/ChatController.java
@@ -74,7 +74,7 @@ public class ChatController {
 		@AuthenticationPrincipal Long userId,
 		@PathVariable @Positive Long roomId) {
 
-		chatService.addParticipantToChat(userId, roomId);
+		chatService.addParticipantToChatWithPessimisticLock(userId, roomId);
 		return ApiResponse.ok();
 	}
 

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/CreateChatRoomReq.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/dto/CreateChatRoomReq.java
@@ -1,9 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.dto;
 
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * 채팅방 생성 요청 dto
@@ -13,9 +11,10 @@ import lombok.NoArgsConstructor;
  * @since 2026.01.22
  */
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
 public class CreateChatRoomReq {
 
 	@Size(max = 255)
-	private String description;
+	private final String description;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
@@ -1,11 +1,17 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 /**
  * .
@@ -23,4 +29,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 	 * chatRoomStatus 를 제외한 상태 조회
 	 */
 	Page<ChatRoom> findByChatRoomStatusNot(ChatRoomStatus chatRoomStatus, Pageable pageable);
+
+    /**
+     * 특정 채팅방(row)에 대해 비관적 쓰기 락(X-lock)을 획득합니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from ChatRoom r where r.id = :roomId")
+    Optional<ChatRoom> findByIdForUpdate(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.github.sleeplessspecialist.peaktime.domain.chat.repository;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoom;
 import com.github.sleeplessspecialist.peaktime.domain.chat.entity.ChatRoomStatus;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -35,5 +37,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select r from ChatRoom r where r.id = :roomId")
+    @QueryHints(
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")
+    )
     Optional<ChatRoom> findByIdForUpdate(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
@@ -162,8 +162,8 @@ public class ChatService {
 	 *
 	 * <p>
 	 *    1. 참여 하고자하는 roomId -> room 이 존재하는지 검증
-	 * 	  2. 현재 인증 userId 가 DB 에 존재하는 user 인지 검증
-	 * 	  3. 채팅방이 OPEN 상태인지 검증 (CLOSED, MATCHED) 이면 참여 불가능
+	 * 	  2. 채팅방이 OPEN 상태인지 검증 (CLOSED, MATCHED) 이면 참여 불가능
+	 * 	  3. 현재 인증 userId 가 DB 에 존재하는 user 인지 검증
 	 * 	  	- 정책 에서 이미 MATCHED 라면 participant.size() = 2 임을 보장
 	 * 	  4. chatRoom 에 연관된 participant 에 user 가 존재하는지 검증
 	 * 	  	- 정책 에서 참여자 상태가 host 여야 하지만 room 이 현재 user 를 포함하는지 검증이 더 포괄적인 검증
@@ -175,9 +175,9 @@ public class ChatService {
     public void addParticipantToChat(Long userId, Long roomId) {
 
         ChatRoom chatRoom = getChatRoom(roomId);
-        User user = getUser(userId);
 
         validateJoinableRoom(chatRoom, roomId, userId);
+        User user = getUser(userId);
         validateNotAlreadyParticipant(chatRoom, user, roomId, userId);
 
         ChatParticipant chatParticipant = ChatParticipant.builder()
@@ -199,9 +199,9 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findByIdForUpdate(roomId)
                 .orElseThrow(() -> new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
+        validateJoinableRoom(chatRoom, roomId, userId);
         User user = getUser(userId);
 
-		validateJoinableRoom(chatRoom, roomId, userId);
 		validateNotAlreadyParticipant(chatRoom, user, roomId, userId);
 
 		ChatParticipant chatParticipant = ChatParticipant.builder()

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/domain/chat/service/ChatService.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  * 커피쳇(Chat) 도메인의 핵심 비즈니스 로직을 처리하는 서비스 클래스입니다.
  *
  * @author 주우재
- * @version 1.0
+ * @version 1.1
  * @since 2026.01.22
  */
 
@@ -171,11 +171,35 @@ public class ChatService {
 	 * </p>
 	 *
 	 */
-	@Transactional
-	public void addParticipantToChat(Long userId, Long roomId) {
+    @Transactional
+    public void addParticipantToChat(Long userId, Long roomId) {
 
-		ChatRoom chatRoom = getChatRoom(roomId);
-		User user = getUser(userId);
+        ChatRoom chatRoom = getChatRoom(roomId);
+        User user = getUser(userId);
+
+        validateJoinableRoom(chatRoom, roomId, userId);
+        validateNotAlreadyParticipant(chatRoom, user, roomId, userId);
+
+        ChatParticipant chatParticipant = ChatParticipant.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .roleInRoom(RoleInRoom.GUEST)
+                .build();
+        chatParticipantRepository.save(chatParticipant);
+
+        chatRoom.matched();
+    }
+
+    /**
+     * 커피쳇 참여 - 비관적 락을 적용한 ver
+     */
+    @Transactional
+	public void addParticipantToChatWithPessimisticLock(Long userId, Long roomId) {
+
+        ChatRoom chatRoom = chatRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        User user = getUser(userId);
 
 		validateJoinableRoom(chatRoom, roomId, userId);
 		validateNotAlreadyParticipant(chatRoom, user, roomId, userId);

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalErrorCode.java
@@ -24,13 +24,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
 
-	INVALID_REQUEST("G400", "INVALID_REQUEST", HttpStatus.BAD_REQUEST),
-	UNAUTHORIZED("G401", "UNAUTHORIZED", HttpStatus.UNAUTHORIZED),
-	ACCESS_DENIED("G403", "ACCESS_DENIED", HttpStatus.FORBIDDEN),
-	DATA_INTEGRITY_VIOLATION("G409", "DATA_INTEGRITY_VIOLATION", HttpStatus.CONFLICT),
-	INTERNAL_SERVER_ERROR("G500", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+    INVALID_REQUEST("G400", "INVALID_REQUEST", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("G401", "UNAUTHORIZED", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED("G403", "ACCESS_DENIED", HttpStatus.FORBIDDEN),
+    DATA_INTEGRITY_VIOLATION("G409", "DATA_INTEGRITY_VIOLATION", HttpStatus.CONFLICT),
+    INTERNAL_SERVER_ERROR("G500", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR),
+    LOCK_ACQUISITION_FAILED("G410", "LOCK_ACQUISITION_FAILED", HttpStatus.CONFLICT);
 
-	private final String code;
-	private final String message;
-	private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/error/GlobalExceptionHandler.java
@@ -2,9 +2,13 @@ package com.github.sleeplessspecialist.peaktime.global.common.error;
 
 import java.util.List;
 
+import jakarta.persistence.PessimisticLockException;
 import lombok.extern.slf4j.Slf4j;
 
+import org.hibernate.exception.LockAcquisitionException;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -65,6 +69,22 @@ public class GlobalExceptionHandler {
 			.status(GlobalErrorCode.DATA_INTEGRITY_VIOLATION.getHttpStatus())
 			.body(ErrorResponse.from(GlobalErrorCode.DATA_INTEGRITY_VIOLATION));
 	}
+
+    @ExceptionHandler({
+            PessimisticLockException.class,
+            LockAcquisitionException.class,
+            CannotAcquireLockException.class,
+            PessimisticLockingFailureException.class
+    })
+    public ResponseEntity<ErrorResponse> handleLockAcquisitionFailedException(Exception e) {
+
+        log.warn("비관적 락 획득 실패 또는 타임아웃 발생");
+        log.debug("락 예외 상세", e);
+
+        return ResponseEntity
+                .status(GlobalErrorCode.LOCK_ACQUISITION_FAILED.getHttpStatus())
+                .body(ErrorResponse.from(GlobalErrorCode.LOCK_ACQUISITION_FAILED));
+    }
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception e) {

--- a/src/test/java/com/github/sleeplessspecialist/peaktime/domain/chat/ChatPessimisticLockTest.java
+++ b/src/test/java/com/github/sleeplessspecialist/peaktime/domain/chat/ChatPessimisticLockTest.java
@@ -1,0 +1,147 @@
+package com.github.sleeplessspecialist.peaktime.domain.chat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomReq;
+import com.github.sleeplessspecialist.peaktime.domain.chat.dto.CreateChatRoomRes;
+import com.github.sleeplessspecialist.peaktime.domain.chat.repository.ChatParticipantRepository;
+import com.github.sleeplessspecialist.peaktime.domain.chat.service.ChatService;
+import com.github.sleeplessspecialist.peaktime.domain.user.entity.User;
+import com.github.sleeplessspecialist.peaktime.domain.user.repository.UserRepository;
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * 비관적 락 vs 일반 트랜잭션 동시성 비교 테스트 입니다.(Service 레이어)
+ *
+ * <p>
+ * 동일한 조건에서
+ * 1) addParticipantToChat(일반)
+ * 2) addParticipantToChatWithPessimisticLock(비관적 락)
+ * 을 각각 수행하여 최종 참여자 수를 비교합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026.
+ */
+@SpringBootTest
+@EnableJpaAuditing
+@ActiveProfiles("test")
+class ChatPessimisticLockTest {
+
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @Test
+    void pessimisticLock_vs_normal_dataIntegrity() throws InterruptedException {
+
+        int threadCount = 50;
+
+        // =========================
+        // 일반 트랜잭션 (동시성 문제 발생 가능)
+        // =========================
+        Long normalHostId = createUser("normal-host");
+
+        CreateChatRoomRes normalRoomRes = chatService.createRoom(
+                normalHostId,
+                CreateChatRoomReq.builder()
+                        .description("normal-room")
+                        .build()
+        );
+        Long normalRoomId = normalRoomRes.getRoomId();
+
+        ExecutorService normalExecutor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch normalLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            Long guestId = createUser("normal-guest-" + i);
+
+            normalExecutor.submit(() -> {
+                try {
+                    chatService.addParticipantToChat(guestId, normalRoomId);
+                } catch (Exception e) {
+                    System.out.println(e.getMessage());
+                } finally {
+                    normalLatch.countDown();
+                }
+            });
+        }
+
+        normalLatch.await();
+        normalExecutor.shutdown();
+
+        long normalParticipantCount = chatParticipantRepository.countByChatRoomId(normalRoomId);
+
+        // =========================
+        // 비관적 락 (동시성 문제 해결)
+        // =========================
+        Long lockHostId = createUser("lock-host");
+
+        CreateChatRoomRes lockRoomRes = chatService.createRoom(
+                lockHostId,
+                CreateChatRoomReq.builder()
+                        .description("lock-room")
+                        .build()
+        );
+        Long lockRoomId = lockRoomRes.getRoomId();
+
+        ExecutorService lockExecutor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch lockLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            Long guestId = createUser("lock-guest-" + i);
+
+            lockExecutor.submit(() -> {
+                try {
+                    chatService.addParticipantToChatWithPessimisticLock(guestId, lockRoomId);
+                } catch (Exception e) {
+                    System.out.println(e.getMessage());
+                } finally {
+                    lockLatch.countDown();
+                }
+            });
+        }
+
+        lockLatch.await();
+        lockExecutor.shutdown();
+
+        long lockParticipantCount = chatParticipantRepository.countByChatRoomId(lockRoomId);
+
+        // =========================
+        // 결과 출력
+        // =========================
+        System.out.println("=== 데이터 정합성 비교 ===");
+        System.out.println("일반 트랜잭션 최종 참여자 수: " + normalParticipantCount + " (예상: 2 초과 가능)");
+        System.out.println("비관적 락 최종 참여자 수: " + lockParticipantCount + " (예상: 2)");
+    }
+
+    private Long createUser(String name) {
+
+        String email = name + "-" + System.nanoTime() + "@test.com";
+
+        User user = User.createForSignup(
+                name,
+                email,
+                "encodedPassword",
+                "01012345678"
+        );
+
+        userRepository.save(user);
+
+        return user.getId();
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #143 
---

## ✨ 작업 내용

### 🧩 커피챗 참여 동시성 문제 해결 (비관적 락 적용)

커피챗 참여 기능은 정원(2명)이 존재하는 구조입니다.  
기존 로직은 참여 전 현재 인원 수를 조회한 뒤 검증하는 방식이었으며,  
동시에 여러 요청이 들어올 경우 다음과 같은 문제가 발생할 수 있었습니다.

- 여러 트랜잭션이 동일 시점에 현재 참여자 수를 조회
- 모두 정원 미달로 판단
- 동시에 참가자 저장
- 결과적으로 정원 초과 발생 (데이터 정합성 깨짐)

이를 해결하기 위해 **채팅방 단위로 비관적 쓰기 락(Pessimistic Write Lock)** 을 적용했습니다.

### ✅ 개선 방식

- 참여 요청 시 채팅방 row에 대한 쓰기 락을 선점
- 하나의 트랜잭션만 참여 로직을 수행
- 나머지 트랜잭션은 대기 후 순차 실행
- 정원 초과 방지
- 상태 전이(MATCHED)와 참가자 저장의 일관성 보장

### 📌 기대 효과

- 동시 참여 요청 환경에서도 정원 초과 불가
- 채팅방 상태 전이의 원자성 보장
- 데이터 정합성 유지
- 실서비스 환경에서의 레이스 컨디션 방지

---

## 🧪 테스트

동시성 테스트를 통해 일반 방식과 비관적 락 적용 방식을 비교했습니다.

- 동일 채팅방에 대해 다수 스레드 동시 참여 요청
- 일반 방식: 정원 초과 발생 가능
- 비관적 락 적용: 항상 정원 2명 유지

로그를 통해 두 방식의 결과 차이를 확인했습니다.

<img width="467" height="91" alt="image" src="https://github.com/user-attachments/assets/b485f896-e96e-46ab-af12-f4fdcf279cd6" />

---

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다.

---

## 💬 리뷰어에게

- 비관적 락 적용 범위가 적절한지 검토 부탁드립니다.
- 현재 요구사항 대비 락 전략이 과도하지 않은지 의견 부탁드립니다.
- 향후 확장(정원 증가, 정책 변경 등) 시 고려해야 할 부분이 있다면 피드백 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 채팅방 입장 시 동시성 처리 방식이 강화되어 다수 동시 접근 상황에서도 참가자 추가가 더 안정적으로 동작합니다. 채팅 신뢰성이 향상됩니다.
* **오류 처리**
  * 잠금 획득 실패 상황에 대해 별도 응답을 추가하여 관련 오류 발생 시 명확한 충돌 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->