### PR TITLE
[chore] Swagger(springdoc-openapi) 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testImplementation "org.testcontainers:mysql:1.20.4"
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.20.4"
     testImplementation "org.testcontainers:mysql:1.20.4"
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/common/security/policy/SecurityPathPolicy.java
@@ -14,71 +14,78 @@ package com.github.sleeplessspecialist.peaktime.global.common.security.policy;
  */
 public final class SecurityPathPolicy {
 
-	/**
-	 * 공개(permitAll) 엔드포인트 목록입니다.
-	 * <p>
-	 * 인증/인가(비로그인 가능)
-	 * </p>
-	 */
-	public static final String[] PUBLIC_ENDPOINTS = {
-		"/error",
+    /**
+     * 공개(permitAll) 엔드포인트 목록입니다.
+     * <p>
+     * 인증/인가(비로그인 가능)
+     * </p>
+     */
+    public static final String[] PUBLIC_ENDPOINTS = {
+            "/error",
 
-		// ✅ 모니터링(Actuator)
-		"/actuator/health",
-		"/actuator/info",
-		"/actuator/prometheus",
-
-
-		// ✅ 기본 프론트 진입
-		"/",
-		"/index.html",
-		"/signup.html",
-		"/favicon.ico",
-		// ✅ 비밀번호 재설정 화면 진입(메일 링크)
-		"/reset-password",
-		"/reset-password.html",
+            // ✅ 모니터링(Actuator)
+            "/actuator/health",
+            "/actuator/info",
+            "/actuator/prometheus",
 
 
-		// 정적 리소스
-		"/css/**",
-		"/js/**",
-		"/images/**",
+            // ✅ 기본 프론트 진입
+            "/",
+            "/index.html",
+            "/signup.html",
+            "/favicon.ico",
+            // ✅ 비밀번호 재설정 화면 진입(메일 링크)
+            "/reset-password",
+            "/reset-password.html",
 
-		// 인증/인가(비로그인 가능)
-		"/api/v2/auth/signup",
-		"/api/v2/auth/login",
-		"/api/v2/auth/reissue",
-		"/api/v2/auth/logout",
-		"/api/v2/auth/password/**",
 
-		// OAuth2
-		"/oauth2/**",
-		"/login/oauth2/**",
-		"/api/v2/oauth2/**"
-	};
+            // 정적 리소스
+            "/css/**",
+            "/js/**",
+            "/images/**",
 
-	/**
-	 * 공개 조회(GET) 엔드포인트 목록입니다.
-	 * <p>
-	 * 명세에서 "공통(비로그인)"으로 정의된 조회 API만 포함합니다.
-	 * (중요) POST/PATCH/DELETE까지 열리지 않도록 SecurityConfig에서 HttpMethod.GET와 함께 사용해야 합니다.
-	 * </p>
-	 */
-	public static final String[] PUBLIC_GET_ENDPOINTS = {
-		"/api/v1/courses",
-		"/api/v1/courses/*",
-		"/api/v1/reviews",
-		"/api/v1/reviews/*",
-		"/api/v1/chat/room",
-        "/api/v1/courses/ranking/last-3-days"
-	};
+            // swagger
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/webjars/**",
 
-	// 관리자
-	public static final String ADMIN_ENDPOINTS = "/api/v1/admin/**";
+            // 인증/인가(비로그인 가능)
+            "/api/v2/auth/signup",
+            "/api/v2/auth/login",
+            "/api/v2/auth/reissue",
+            "/api/v2/auth/logout",
+            "/api/v2/auth/password/**",
 
-	// 강의자
-	public static final String LECTURER_ENDPOINTS = "/api/v1/lecturer/**";
 
-	private SecurityPathPolicy() {
-	}
+            // OAuth2
+            "/oauth2/**",
+            "/login/oauth2/**",
+            "/api/v2/oauth2/**"
+    };
+
+    /**
+     * 공개 조회(GET) 엔드포인트 목록입니다.
+     * <p>
+     * 명세에서 "공통(비로그인)"으로 정의된 조회 API만 포함합니다.
+     * (중요) POST/PATCH/DELETE까지 열리지 않도록 SecurityConfig에서 HttpMethod.GET와 함께 사용해야 합니다.
+     * </p>
+     */
+    public static final String[] PUBLIC_GET_ENDPOINTS = {
+            "/api/v1/courses",
+            "/api/v1/courses/*",
+            "/api/v1/reviews",
+            "/api/v1/reviews/*",
+            "/api/v1/chat/room",
+            "/api/v1/courses/ranking/last-3-days"
+    };
+
+    // 관리자
+    public static final String ADMIN_ENDPOINTS = "/api/v1/admin/**";
+
+    // 강의자
+    public static final String LECTURER_ENDPOINTS = "/api/v1/lecturer/**";
+
+    private SecurityPathPolicy() {
+    }
 }

--- a/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/swagger/OpenApiConfig.java
+++ b/src/main/java/com/github/sleeplessspecialist/peaktime/global/config/swagger/OpenApiConfig.java
@@ -1,0 +1,64 @@
+package com.github.sleeplessspecialist.peaktime.global.config.swagger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+
+/**
+ * Swagger(OpenAPI) 문서 설정 클래스입니다.
+ *
+ * <p>
+ * - Peak-Time API의 기본 문서 정보(title, version, description)를 정의합니다.
+ * - JWT 기반 Bearer 인증 방식을 Swagger 문서에 반영합니다.
+ * - Swagger UI의 Authorize 버튼을 통해 JWT 토큰을 입력하여
+ *   보호된 API를 테스트할 수 있도록 보안 스키마를 설정합니다.
+ * </p>
+ *
+ * @author 주우재
+ * @version 1.0
+ * @since 2026. 02. 26
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Peak-Time API",
+                version = "v1",
+                description = "Peak-Time REST API documentation"
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class OpenApiConfig {
+
+    /**
+     * OpenAPI 문서의 추가 메타 정보를 설정합니다.
+     *
+     * <p>
+     * API 문서의 제목, 버전, 설명, 연락처 정보를 정의합니다.
+     * Swagger UI 상단에 표시되는 기본 정보를 구성하는 역할을 합니다.
+     * </p>
+     *
+     * @return OpenAPI 설정 객체
+     */
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new io.swagger.v3.oas.models.info.Info()
+                        .title("Peak-Time API")
+                        .version("v1")
+                        .description("Peak-Time REST API documentation")
+                        .contact(new Contact().name("Peak-Time Team")));
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request Template

## 🔗 관련 Issue
- close #184

---

## ✨ 작업 내용
SpringDoc(OpenAPI 3) 기반 Swagger UI를 프로젝트에 적용하였습니다.  
이를 통해 API 명세를 자동 생성하고, 개발 및 테스트 과정에서 API 스펙을 직관적으로 확인할 수 있도록 구성했습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

### 📌 주요 변경 사항
- springdoc-openapi 의존성 추가
- Swagger UI 기본 설정 적용
- `/swagger-ui/index.html` 경로 정상 접근 확인
- OpenAPI 기본 정보(title, version 등) 설정
- (Security 사용 시) Swagger 경로 접근 허용 처리

---

## 📸 스크린샷 (선택)
<img width="1729" height="768" alt="image" src="https://github.com/user-attachments/assets/40bb9b19-8692-4e27-a322-98d930de523f" />


---

## ✅ 체크리스트
PR 제출 전 확인해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 관련 Issue를 연결했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [ ] 테스트 코드를 추가/수정했습니다. (해당 시)

---

## 💬 리뷰어에게
단순히  swagger 의 기본 설정만 추가 되었습니다. 추가로 더 필요한것이 있는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Swagger/OpenAPI UI 통합으로 API 문서를 시각적으로 탐색 및 테스트 가능
  * API 문서에서 JWT Bearer 토큰으로 인증하여 요청 시도 가능
  * 엔드포인트 역할 분류 추가(공개, 관리자, 강사)로 접근 범위 명시화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->